### PR TITLE
Use exp decay

### DIFF
--- a/validator/validator_daemon.py
+++ b/validator/validator_daemon.py
@@ -132,9 +132,11 @@ def main():
                     continue
 
                 bt.logging.info(f"Moving scores: {moving_scores}")
-                arr = np.array(moving_scores)
-                exp_arr = np.exp(arr)
-                weights = (exp_arr / np.sum(exp_arr)).tolist()
+                arr = np.array(moving_scores, dtype=np.float32)
+                scale   = 8.0
+                deltas  = arr.max() - arr
+                exp_dec = np.exp(-deltas / scale)
+                weights = (exp_dec / exp_dec.sum()).tolist()
                 bt.logging.info(f"Setting weights on chain: {weights}")
                 subtensor.set_weights(
                     netuid=config.netuid,

--- a/validator/validator_daemon.py
+++ b/validator/validator_daemon.py
@@ -136,7 +136,7 @@ def main():
                 scale   = 8.0
                 deltas  = arr.max() - arr
                 exp_dec = np.exp(-deltas / scale)
-                weights = (exp_dec / exp_dec.sum()).tolist()
+                weights = ((exp_dec / exp_dec.sum())*65535).tolist()
                 bt.logging.info(f"Setting weights on chain: {weights}")
                 subtensor.set_weights(
                     netuid=config.netuid,


### PR DESCRIPTION
uses exponential decay from the leader in order to avoid variance "spikes" that reduce validator V-Trust.

# problem
`softmax` against current scores penalizes the inactive folks well, but our natural additive scoring is resulting in numbers high enough that small variances (1 or two successful queries) result in orders of magnitude difference. 

# solution
use a simple distance (just delta between top score and particular score) and apply exponential decay. tested on our validator 0 and already see better, less spiky distribution for incentives.

# todo
- long-term use logs of raw / additive scores to better understand what the distribution looks like over time so that we can adjust the scoring / functions against scores. there might be a "natural" method of combining factors to generate scores, but still need to make sure any resulting curves create competition so that eeking out that last bit of performance is worth it.
- we'll need to update incentives as time goes on, but let's seek out adaptive frameworks so that we don't need to frequently change magic numbers like the `scale` that is used here.