### PR TITLE
Release/v0.0.28

### DIFF
--- a/shared/veridex_protocol.py
+++ b/shared/veridex_protocol.py
@@ -50,6 +50,7 @@ class VericoreStatementResponse():
   is_similar_context: bool=False
   approved_url_multiplier:float=0
   page_text: str = ""
+  assessment_result: dict = field(default_factory=dict)
 
 @dataclass
 class VericoreMinerStatementResponse():

--- a/validator/snippet_validator.py
+++ b/validator/snippet_validator.py
@@ -541,7 +541,8 @@ class SnippetValidator:
                         local_score=0.0,
                         snippet_score=snippet_score,
                         snippet_score_reason="unrelated_page_snippet",
-                        rejection_reason = assessment_result.get("reason")
+                        rejection_reason = assessment_result.get("reason"),
+                        assessment_result = assessment_result
                     )
                 elif snippet_result == "FAKE":
                     snippet_score = FAKE_SNIPPET
@@ -553,6 +554,7 @@ class SnippetValidator:
                         local_score=0.0,
                         snippet_score=snippet_score,
                         snippet_score_reason="fake_page_snippet",
+                        assessment_result=assessment_result,
                         rejection_reason = assessment_result.get("reason")
                     )
                 elif is_search_url:
@@ -564,6 +566,7 @@ class SnippetValidator:
                         snippet_found=False,
                         local_score=0.0,
                         snippet_score=snippet_score,
+                        assessment_result=assessment_result,
                         snippet_score_reason="is_search_web_page",
                         rejection_reason = assessment_result.get("reason")
                     )
@@ -589,6 +592,7 @@ class SnippetValidator:
                     local_score=0.0,
                     snippet_score=snippet_score,
                     snippet_score_reason="snippet_not_verified_in_url",
+                    assessment_result=assessment_result,
                     page_text=page_text if DEBUG_LOCAL else ""
                 )
                 return vericore_miner_response
@@ -614,6 +618,7 @@ class SnippetValidator:
                     snippet_score=snippet_score,
                     snippet_score_reason="snippet_not_context_similar",
                     context_similarity_score=context_similarity_score,
+                    assessment_result=assessment_result,
                     page_text=""
                 )
 
@@ -637,7 +642,8 @@ class SnippetValidator:
                 snippet_score=0,
                 context_similarity_score=context_similarity_score,
                 statement_similarity_score=statement_similarity_score,
-                is_similar_context=is_similar_excerpt
+                is_similar_context=is_similar_excerpt,
+                assessment_result=assessment_result
             )
             end_time = time.time()
             bt.logging.info(

--- a/validator/snippet_validator.py
+++ b/validator/snippet_validator.py
@@ -195,7 +195,8 @@ class SnippetValidator:
         path_parts = [unquote_plus(part.strip()) for part in parsed.path.split('/') if part]
 
         for part_index, part in enumerate(path_parts):
-            if re.search(r"[\\/]*search[\\/]*", part):
+            if part.lower() == "search":
+            # if re.search(r"[\\/]*search[\\/]*", part):
                 bt.logging.info(f"{request_id} | {miner_uid} | {miner_evidence.url} | {part} | search is part of url")
                 snippet_score = USING_SEARCH_AS_EVIDENCE
                 return VericoreStatementResponse(

--- a/validator/statement_context_evaluator.py
+++ b/validator/statement_context_evaluator.py
@@ -30,8 +30,21 @@ async def assess_statement_async(request_id: str, miner_uid: int, statement_url:
         You need to also check whether the excerpt might be fake. The excerpt repeats the statement verbatim or nearly verbatim, but uses vague, evasive, or overly dramatic language that obscures meaning and does not engage meaningfully with the statement
         Additionally, check if the URL looks like a search results page (for example, if it contains 'search', 'q=', or comes from a search engine domain) and if the search query or URL content is similar to the statement or excerpt content.
 
-        Return the reason for your answer as well as the result:
-        {{ "reason:"", "snippet_status": "SUPPORT", "is_search_url": false  }}
+You are given the output of a Natural Language Inference (NLI) model to help you decide. The model is used as follows:
+- The `excerpt` is the *premise*.
+- The `statement` is the *hypothesis*.
+- The model returns logits for 3 labels in this order: [contradiction, neutral, entailment].
+- These logits are passed through a softmax layer to obtain probabilities:
+  - "contradiction": the probability that the excerpt contradicts the statement.
+  - "neutral": the probability that the excerpt neither supports nor contradicts the statement.
+  - "entailment": the probability that the excerpt supports the statement.
+
+        Use:
+        - local_score = contradiction + entailment (do not subtract neutrality)
+        to determine confidence in classification.
+
+        Return the reason for your answer as well as the result: Return the reason for your score.
+        {{ "reason:"", "snippet_status": "SUPPORT", "is_search_url": false, "score": {{ "contradiction": 0.0, "entailment": 0.0, "neutral": 0.0 }}   }}
 
 - snippet_status: One of "SUPPORT", "CONTRADICT", or "UNRELATED", or "FAKE" .
 - is_search_url: true if the URL is a search page and is similar to the statement; otherwise false.
@@ -43,7 +56,6 @@ Definitions:
 
 Do not include explanations. Only return the JSON object.
 """
-
                                       },
         {"role": "user", "content": f"""
         Webpage Excerpt: {webpage[:1500]}


### PR DESCRIPTION
**LLM Excerpt Update:**  
  The LLM prompt and assessment logic were updated to return explicit scoring for `contradiction`, `neutral`, and `entailment` statements. This allows for clearer evaluation of statement relationships.

**Assessment Result Return:**  
  The validator logic now returns the LLM assessment result, making the output more informative and traceable.

**URL Check Modification:**  
  The URL validation was changed to only accept the exact word "search" (case-insensitive), rather than using a regex or partial matching. This ensures stricter URL validation in the relevant logic.