### PR TITLE
Release/v0.0.31.2

### DIFF
--- a/documents/miner_rejection_and_snippet_reasons.md
+++ b/documents/miner_rejection_and_snippet_reasons.md
@@ -1,0 +1,108 @@
+# Miner rejection and snippet reasons
+
+Canonical list of miner-level status values and snippet-level score/rejection reasons for Subnet 70 (Vericore), for dashboards, ops, and miner tooling. For the high-level scoring formula and domain/speed factors, see [scoring_mechanics_subnet_70.md](scoring_mechanics_subnet_70.md).
+
+---
+
+## 1. Miner-level status (rejection) reasons
+
+**Source:** [validator/api_server.py](../validator/api_server.py) — `VericoreMinerStatementResponse.status` and associated scores.
+
+| Status | Score | When |
+|--------|-------|------|
+| `invalid_miner` | 0 | Miner UID not found for hotkey |
+| `unreachable_miner` | -10 | No `axon_info` or `not axon_info.is_serving` |
+| `no_response` | -10 | Miner response is None, or `veridex_response` is None, or exception during `call_axon` |
+| `no_statements_provided` | -5 | Miner returned empty list of evidence |
+| `ok` | (computed) | Normal path; score from snippets + speed factor |
+| `error` | -10 | Exception in `process_miner_response` |
+| `duplicate_miner_statements` | 0 | Same excerpts/URLs as another miner, slower response |
+
+Constants: `UNREACHABLE_MINER_SCORE`, `INVALID_RESPONSE_MINER_SCORE`, `NO_STATEMENTS_PROVIDED_SCORE`, `DUPLICATE_EXACT_MINER_STATEMENTS` from [shared/scores.py](../shared/scores.py).
+
+---
+
+## 2. Snippet-level reasons (`snippet_score_reason`)
+
+**Source:** [validator/snippet_validator.py](../validator/snippet_validator.py) (and one in [validator/api_server.py](../validator/api_server.py)). Each snippet gets a `VericoreStatementResponse` with `snippet_score_reason` and `snippet_score`.
+
+| snippet_score_reason | Score | Description |
+|----------------------|-------|-------------|
+| `query_parameter_same_as_evidence` | -5 | URL query/path too similar to statement (search gaming) |
+| `using_search_in_url_as_evidence` | -5 | Path contains "search" |
+| `using_search_as_part_of_url` | -5 | Last path part looks like a search sentence |
+| `using_search_as_evidence:%20` | -5 | Last path part contains "%20" (search-like) |
+| `excerpt_is_same_as_url` | -5 | Excerpt matches URL path (search gaming) |
+| `blacklisted_url` | -5 | Domain on blacklist |
+| `domain_is_recently_registered` | -1 | Domain registration too recent |
+| `ssl_url_required` | -2 | Non-HTTPS URL |
+| `no_snippet_provided` | -5 | Empty excerpt |
+| `snippet_same_as_statement` | -10 | Excerpt identical to statement |
+| `invalid_excerpt` | -5 | Fails `is_valid_separator_sentence` (e.g. too short) |
+| `excerpt_too_similar` | -5 | Snippet too similar to statement |
+| `could_not_extract_html_from_url` | 0 | Page fetch returned empty text |
+| `is_search_web_page` | -5 | Page content detected as search results page (or assessment `is_search_url`) |
+| `unrelated_page_snippet` | 0 | AI: excerpt unrelated to statement |
+| `fake_page_snippet` | -5 | AI: excerpt fake/vague/evasive |
+| `snippet_not_verified_in_url` | -1 | Snippet text not found in fetched page |
+| `too_many_snippets` | 0 | Snippets beyond MAX_MINER_RESPONSES (api_server) |
+| `error_verifying_miner_snippet` | -1 | Exception during snippet validation |
+
+---
+
+## 3. rejection_reason (AI free-text)
+
+`rejection_reason` is set from `assessment_result.get("reason")` only when the validator uses the AI assessment and returns UNRELATED, FAKE, or `is_search_url` — i.e. in [validator/snippet_validator.py](../validator/snippet_validator.py) for `snippet_result == "UNRELATED"`, `snippet_result == "FAKE"`, or when `is_search_url` is true.
+
+Known patterns from [validator/open_ai_client_handler.py](../validator/open_ai_client_handler.py) (when assessment fails or is filtered):
+
+- `"Prompt was filtered due to policy violation in category '{category}'."` — snippet_status set to FAKE
+- `"Error: {error_str}."` — snippet_status set to ERROR
+- `"Error Parsing Json: {e}."` — snippet_status set to ERROR
+
+Otherwise the reason is free-text from the AI model (e.g. why excerpt was classified UNRELATED or FAKE). If storing `rejection_reason`, consider aggregating phrases or a word cloud for miner feedback.
+
+---
+
+## 4. Recommended charts (validator / ops)
+
+- **Miner status distribution** — Bar or pie of `status` counts (ok vs unreachable_miner vs no_response vs no_statements_provided vs error vs duplicate_miner_statements vs invalid_miner) to see overall health.
+- **Snippet reason distribution** — Bar chart of `snippet_score_reason` counts (over all snippets or per request) to see main failure modes.
+- **Snippet reasons over time** — Time series of counts per `snippet_score_reason` to spot trends (e.g. rise of search-as-evidence).
+- **Snippet reasons by miner** — Heatmap or stacked bar: miner_uid (or hotkey) vs top `snippet_score_reason` to see which miners get which failures.
+- **Score by miner status** — Distribution of `final_score` by `status` (e.g. box plot) to confirm score mapping.
+- **Top rejection_reason phrases** — If storing `rejection_reason`: word cloud or aggregated phrases for UNRELATED/FAKE/search to guide miner feedback (optional).
+
+---
+
+## 5. Charts against veridex_protocol (for the miner)
+
+Charts that miners (or miner dashboards) can build using the protocol types in [shared/veridex_protocol.py](../shared/veridex_protocol.py).
+
+### Miner request/response (VericoreMinerStatementResponse)
+
+- **status** — Bar or pie of `status` (ok, unreachable_miner, no_response, no_statements_provided, error, duplicate_miner_statements) so miners see their own outcome mix.
+- **final_score vs elapsed_time** — Scatter: `final_score` (y) vs `elapsed_time` (x) to see speed–score tradeoff.
+- **raw_score vs speed_factor** — How much of `final_score` comes from content (`raw_score`) vs speed (`speed_factor`).
+- **snippet_count** — Distribution of `snippet_count` per request (how many snippets sent).
+- **Time breakdown** — Stacked bar or area: `total_fetch_time_secs`, `total_ai_time_secs`, `total_other_time_secs` per request (or averaged over time).
+- **avg_snippet_time_secs / max_snippet_time_secs** — Time series or distribution to spot slow snippets.
+
+### Per-snippet (VericoreStatementResponse)
+
+- **snippet_score_reason** — Bar chart of `snippet_score_reason` counts (miner’s own snippets) to see why snippets fail or get low scores.
+- **snippet_found** — Proportion of snippets with `snippet_found=True` vs False.
+- **local_score vs snippet_score** — Scatter or box: effect of `domain_factor` and `approved_url_multiplier`.
+- **NLI probs** — Distribution of `contradiction`, `neutral`, `entailment` (e.g. small histograms or ternary) to see support/contradict mix.
+- **Timing** — `verify_miner_time_taken_secs` vs `snippet_fetcher_http_time_secs` / `snippet_fetcher_selenium_time_secs` / `snippet_fetcher_total_time_secs` to see fetch vs AI vs other.
+- **Signals** — Optional: distributions of `sentiment`, `conviction`, `source_credibility`, `narrative_momentum`, `risk_reward_sentiment`, `catalyst_detection`, `political_leaning` for accepted snippets.
+
+### Miner output (VericoreSynapse / SourceEvidence)
+
+- **Snippets per request** — Distribution of `len(veridex_response)` (how many `SourceEvidence` items sent).
+- **Excerpt length** — Distribution of `len(excerpt)` (or word count) per snippet.
+- **URL/domain** — Domain (or TLD) distribution of `url` to see source diversity and overuse of one domain.
+
+### Optional: request-level (VericoreQueryResponse)
+
+- If the miner sees query-level aggregates: **miner_count**, **total_snippet_count**, **total_elapsed_time** vs **total_fetch_time_secs** / **total_ai_time_secs** for context (e.g. validator-side totals).

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pydantic
 transformers
 selenium
 fuzzywuzzy
+python-Levenshtein  # required: fuzzywuzzy's pure-Python fallback gives wrong partial_ratio for short-vs-long (snippet vs page)
 sentence-transformers
 python-whois
 beautifulsoup4

--- a/shared/environment_variables.py
+++ b/shared/environment_variables.py
@@ -12,7 +12,7 @@ AI_API_URL = os.environ.get("AI_API_URL", "https://api.dashboard.vericore.dfusio
 USE_HTML_PARSER_API = os.environ.get("USE_HTML_PARSER_API", "False").lower() == 'true'
 HTML_PARSER_API_URL = os.environ.get("HTML_PARSER_API_URL", "https://api.snippet-fetcher.vericore.dfusion.ai")
 
-VERICORE_VALIDATOR_VERSION = os.environ.get("VERICORE_VALIDATOR_VERSION", "v0.0.36")
+VERICORE_VALIDATOR_VERSION = os.environ.get("VERICORE_VALIDATOR_VERSION", "v0.0.43.2")
 
 INITIAL_WEIGHT = 0.7
 

--- a/validator/snippet_validator.py
+++ b/validator/snippet_validator.py
@@ -7,6 +7,8 @@ import re
 import os
 from urllib.parse import urlparse, parse_qs, unquote_plus
 
+# python-Levenshtein required: without it, fuzz.partial_ratio uses a buggy pure-Python path
+# that returns wrong low scores for short-vs-long (snippet vs page).
 from fuzzywuzzy import fuzz
 
 from shared.blacklisted_domain_cache import is_blacklisted_domain

--- a/validator/snippet_validator.py
+++ b/validator/snippet_validator.py
@@ -1,10 +1,13 @@
 import time
+import unicodedata
 import bittensor as bt
 import tldextract
 import ipaddress
 import re
 import os
 from urllib.parse import urlparse, parse_qs, unquote_plus
+
+from fuzzywuzzy import fuzz
 
 from shared.blacklisted_domain_cache import is_blacklisted_domain
 from shared.exceptions import InsecureProtocolError
@@ -37,6 +40,10 @@ from validator.statement_context_evaluator import assess_statement_async
 from validator.web_page_validator import is_search_web_page
 
 MIN_SNIPPET_CONTEXT_SIMILARITY_SCORE = .65
+
+# Snippet-in-page verification: fuzzy fallback when exact (normalized) match fails
+FUZZY_VERIFY_THRESHOLD = 0.94  # ratio in [0, 1]; only accept if best match >= this (character-level tolerance only)
+MIN_SNIPPET_LENGTH_FOR_FUZZY = 25  # minimum normalized snippet length to run fuzzy check (avoids trivial matches)
 
 class SnippetValidator:
 
@@ -134,6 +141,8 @@ class SnippetValidator:
     ) -> bool:
         try:
             def normalize_text(text):
+                # Unicode normalization: same character, different bytes (e.g. quotes, accents, compatibility variants)
+                text = unicodedata.normalize("NFKC", text or "")
                 # Remove patterns like [ 1 ], [12], [ 123 ]
                 text = re.sub(r"\[\s*\d+\s*\]", '', text)
                 # Standardize quotes
@@ -158,9 +167,19 @@ class SnippetValidator:
                 if normalized_snippet in normalized_page:
                     bt.logging.info(f"{request_id} | {miner_uid} | {url} | Web page is EXACTLY the same as the snippet (normalized).")
                     return True
-                else:
-                    bt.logging.info(f"{request_id} | {miner_uid} | {url} | Web page is NOT exactly the same as the snippet (normalized)")
-                    return False
+
+                # Fuzzy fallback: same text with character-level differences only (no paraphrase)
+                if len(normalized_snippet) >= MIN_SNIPPET_LENGTH_FOR_FUZZY and normalized_page:
+                    # partial_ratio: best match of snippet against any substring of page (0-100)
+                    ratio = fuzz.partial_ratio(normalized_snippet, normalized_page) / 100.0
+                    if ratio >= FUZZY_VERIFY_THRESHOLD:
+                        bt.logging.info(
+                            f"{request_id} | {miner_uid} | {url} | Snippet verified via fuzzy match (ratio={ratio:.2f}, threshold={FUZZY_VERIFY_THRESHOLD})."
+                        )
+                        return True
+
+                bt.logging.info(f"{request_id} | {miner_uid} | {url} | Web page is NOT exactly the same as the snippet (normalized)")
+                return False
             except Exception as e:
                 bt.logging.error(
                     f"{request_id} | {miner_uid} | {url} | Error verifying snippet in rendered page: {e}"


### PR DESCRIPTION
# Release v0.0.31.2 — Changes vs main

Summary of changes on `release/v0.0.31.2` compared to `main`.

---

## 1. validator/snippet_validator.py

**Snippet-in-page verification**

- **Unicode normalization** — `normalize_text()` now applies `unicodedata.normalize("NFKC", text or "")` first so quotes, accents, and compatibility variants compare consistently.
- **Fuzzy fallback** — When the normalized snippet is *not* an exact substring of the normalized page:
  - For snippets of length ≥ 25, run `fuzz.partial_ratio(snippet, page)`.
  - If ratio ≥ 0.94, treat as verified and return `True`.
- **Constants** — `FUZZY_VERIFY_THRESHOLD = 0.94`, `MIN_SNIPPET_LENGTH_FOR_FUZZY = 25`.
- **Imports** — Added `unicodedata` and `fuzzywuzzy.fuzz`.

Net: same behaviour when exact match succeeds; when it fails, allow a high-threshold fuzzy match for non-trivial snippets (character-level tolerance only, no paraphrase).

---

## 2. documents/miner_rejection_and_snippet_reasons.md (new)

New doc defining:

- **Miner-level status** — `invalid_miner`, `unreachable_miner`, `no_response`, `no_statements_provided`, `ok`, `error`, `duplicate_miner_statements` with scores and when they apply.
- **Snippet-level reasons** — Full table of `snippet_score_reason` (e.g. `snippet_not_verified_in_url`, `could_not_extract_html_from_url`, `fake_page_snippet`) with scores and short descriptions.
- **`rejection_reason`** — When it is set (AI UNRELATED/FAKE/search) and known patterns from the OpenAI handler.
- **Charts** — Suggested validator/ops charts (status distribution, snippet reasons over time, by miner, etc.) and miner-facing charts (status, timing, NLI probs, etc.).

---

## 3. shared/environment_variables.py

- **Default validator version** — `VERICORE_VALIDATOR_VERSION` default changed from `"v0.0.36"` to `"v0.0.43.2"`.

---

## Summary

Snippet verification gains NFKC normalization and a fuzzy-match fallback; default validator version is bumped to v0.0.43.2; and miner/snippet rejection reasons and suggested charts are documented in a new doc.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches validator scoring/verification logic and adds a fuzzy-matching dependency, which can change acceptance rates for borderline snippets; otherwise changes are straightforward and mostly additive/documentation.
> 
> **Overview**
> Improves snippet verification in `validator/snippet_validator.py` by adding Unicode NFKC normalization and a high-threshold fuzzy-match fallback (`fuzz.partial_ratio`) when exact normalized substring matching fails (guarded by minimum snippet length).
> 
> Adds `python-Levenshtein` to `requirements.txt` to ensure correct `fuzzywuzzy` behavior, bumps the default `VERICORE_VALIDATOR_VERSION`, and introduces `documents/miner_rejection_and_snippet_reasons.md` to canonically document miner/snippet rejection reasons and suggested dashboard charts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ced123dbf634ccfab3ded3f6fcff67d561dce50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->