### PR TITLE
Story/mitchell/desearch integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@
 ---
 
 ## Overview
+
 Vericore is a Bittensor subnet seeking to improve large-scale semantic fact-checking and verification. The subnet processes statements and returns evidence-based validation through relevant quotes and source materials that either support or contradict the input claims.
 
 ### Key Features
+
 - **Semantic Analysis**: Processes natural language statements and understands their semantic meaning
 - **Source Verification**: Returns precise quotes and segments from sources
 - **Dual Validation**: Provides both corroborating and contradicting evidence when available
@@ -27,6 +29,7 @@ Vericore is a Bittensor subnet seeking to improve large-scale semantic fact-chec
 - **Source Attribution**: All returned evidence includes traceable source information
 
 ### Use Cases
+
 - Media fact-checking
 - Research validation
 - Content verification
@@ -37,23 +40,56 @@ Vericore is a Bittensor subnet seeking to improve large-scale semantic fact-chec
 
 ```
 Vericore/
+├── docs/
+│   ├── desearch-scoring-flow.md            # Desearch scoring and validation flow
+│   ├── miner_rejection_and_snippet_reasons.md
+│   └── scoring_mechanics_subnet_70.md      # Scoring mechanics documentation
+├── keys/
+│   └── validator_jwt_public.pem            # JWT public key for API auth
 ├── miner/
-    ├── perplexica/
-        └── miner.py         # Sample implementation of a naive miner using Perplexica
-    ├── perplexity/
-        └── miner.py         # Sample implementation of a naive miner using Perplexity
+│   ├── desearch/
+│   │   └── miner.py                        # Miner implementation using Desearch API
+│   ├── perplexica/
+│   │   └── miner.py                        # Sample miner using Perplexica
+│   └── perplexity/
+│       └── miner.py                        # Sample miner using Perplexity
 ├── shared/
-    ├── log_data.py          # Log settings and format
-    ├── proxy_log_handler.py # Log handler
-    └── veridex_protocol.py  # Protocol for comms between Validator and Miner
-└── validator
-    ├── active_tester.py     # Produces tests for the miners
-    ├── api_server.py        # Api Server for receiving statements as input
-    ├── domain_validator.py  # Handles domain validation
-    ├── quality_model.py     # Measure Corroboration or Refutation of statements
-    ├── snippet_fetcher.py   # Fetches referenced source material for validation
-    ├── validator_daemon.py  # Daemon that handles axons / server tasks
-    └── verify_context_quality_model.py
+│   ├── blacklisted_domain_cache.py         # Domain blacklist cache
+│   ├── debug_util.py                       # Debug utilities
+│   ├── desearch_proof.py                   # Desearch proof signature verification
+│   ├── environment_variables.py            # Environment variable definitions
+│   ├── exceptions.py                       # Shared exception types
+│   ├── log_data.py                         # Log settings and format
+│   ├── proxy_log_handler.py                # Log handler
+│   ├── scores.py                           # Scoring constants (penalties, bonuses)
+│   ├── store_results_handler.py            # Results storage handler
+│   ├── top_site_cache.py                   # Approved top-site cache
+│   ├── validator_results_data.py           # Validator results data models
+│   ├── veridex_protocol.py                 # Protocol for comms between Validator and Miner
+│   └── wallet_api_key_utils.py             # Wallet-linked API key utilities
+├── tests/
+│   ├── manual/                             # Manual integration tests
+│   └── unit_tests/                         # Automated unit tests
+├── utils/
+│   ├── generate_wallet_linked_token.py     # Generate wallet-linked JWT tokens
+│   ├── link_desearch_miner.py              # Link a miner wallet to Desearch
+│   ├── test_desearch_verify.py             # Test Desearch signature verification
+│   └── validate_desearch_signature.py      # Validate Desearch API signatures
+├── validator/
+│   ├── active_tester.py                    # Produces tests for the miners
+│   ├── api_server.py                       # API server for receiving statements
+│   ├── context_similarity_validator.py     # Context similarity scoring
+│   ├── domain_validator.py                 # Domain validation (age, registration)
+│   ├── open_ai_client_handler.py           # OpenAI client handler
+│   ├── open_ai_proxy_server_handler.py     # OpenAI proxy server handler
+│   ├── quality_model.py                    # Measure corroboration/refutation of statements
+│   ├── similarity_quality_model.py         # Text similarity quality model
+│   ├── snippet_fetcher.py                  # Fetches referenced source material
+│   ├── snippet_validator.py                # Snippet validation and scoring
+│   ├── statement_context_evaluator.py      # AI-based statement assessment
+│   ├── validator_daemon.py                 # Daemon that handles axons / server tasks
+│   └── web_page_validator.py               # Web page content validation
+└── requirements.txt
 ```
 
 ## Prerequisites
@@ -78,7 +114,6 @@ Instructions for installing and setting up a validator can be found in [Validato
 Register both the miner and validator on the Bittensor network.
 
 - **Register the Miner**:
-
   ```bash
   btcli s register --wallet.name mywallet --wallet.hotkey miner_hotkey
   ```
@@ -86,7 +121,6 @@ Register both the miner and validator on the Bittensor network.
 > **Note**: If you're not connecting to the Mainnet, add `ws://127.0.0.1:9944` or specify the name of the network you wish to connect to.
 
 - **Register the Validator**:
-
   ```bash
   btcli s register --wallet.name mywallet --wallet.hotkey validator_hotkey
   ```
@@ -97,9 +131,10 @@ Register both the miner and validator on the Bittensor network.
 
 ## Scoring Mechanics
 
-For detailed information on how miners are scored and ranked in Subnet 70, see the [Scoring Mechanics Documentation](documents/scoring_mechanics_subnet_70.md).
+For detailed information on how miners are scored and ranked in Subnet 70, see the [Scoring Mechanics Documentation](docs/scoring_mechanics_subnet_70.md).
 
 This document covers:
+
 - Individual snippet scoring
 - Validation penalties and bonuses
 - Moving average system (EWMA)
@@ -127,7 +162,7 @@ You can monitor these logs to observe the interactions and performance metrics.
 ## Running a blockchain locally
 
 This section is for running a local blockchain. The full tutorial is found here:
-https://github.com/opentensor/bittensor-subnet-template/blob/main/docs/running_on_staging.md
+[https://github.com/opentensor/bittensor-subnet-template/blob/main/docs/running_on_staging.md](https://github.com/opentensor/bittensor-subnet-template/blob/main/docs/running_on_staging.md)
 
 ### Install Substrate dependencies
 
@@ -181,12 +216,11 @@ BUILD_BINARY=0 ./scripts/localnet.sh False --no-purge
 
 We are running with fast-block off and using localnet.sh due to the following issues:
 
-https://github.com/opentensor/bittensor-subnet-template/issues/118#issuecomment-2547474216
+[https://github.com/opentensor/bittensor-subnet-template/issues/118#issuecomment-2547474216](https://github.com/opentensor/bittensor-subnet-template/issues/118#issuecomment-2547474216)
 
-https://github.com/opentensor/bittensor-subnet-template/issues/118#issuecomment-2552609160
+[https://github.com/opentensor/bittensor-subnet-template/issues/118#issuecomment-2552609160](https://github.com/opentensor/bittensor-subnet-template/issues/118#issuecomment-2552609160)
 
 **Note**: Watch for any build or initialization outputs in this step. If you are building the project for the first time, this step will take a while to finish building, depending on your hardware.
-
 
 ### Mint tokens from faucet
 

--- a/docs/desearch-scoring-flow.md
+++ b/docs/desearch-scoring-flow.md
@@ -76,7 +76,9 @@ Miner Response Received
          +------------+-------------+
                       |
                       v
-         For each snippet_found: domain_factor = 1/2^times_used (1st use=1.0, 2nd=0.5, 3rd=0.25, ...)
+         For each snippet_found:
+           - Desearch only, and domain is x.com/twitter.com/reddit.com: domain_factor = 1 (no duplicate-domain check)
+           - Web, or desearch with other domains: domain_factor = 1/2^times_used (1st use=1.0, 2nd=0.5, 3rd=0.25, ...)
          snippet_score = local_score × domain_factor × approved_url_multiplier
                       |
                       v
@@ -127,18 +129,19 @@ Each snippet is validated concurrently. When `source_type == "desearch"`:
 Snippets are processed in order. For each response with `snippet_found=True`:
 
 1. **Domain diversity factor**  
-   For each domain, we track how many times it has been used so far in this response. The first snippet from a domain gets no penalty; repeated use of the same domain is discounted:
-   - First use of domain: `domain_factor = 1.0`
-   - Second use: `domain_factor = 0.5`
-   - Third use: `domain_factor = 0.25`
-   - Fourth use: `domain_factor = 0.125`
-   - etc. (formula: `domain_factor = 1 / 2^times_used`)
+   - **Desearch only, and domain is x.com, twitter.com, or reddit.com**: `domain_factor = 1` (no duplicate-domain check).
+   - **Web, or desearch with any other domain**: For each domain we track how many times it has been used so far in this response. The first snippet from a domain gets no penalty; repeated use of the same domain is discounted:
+     - First use of domain: `domain_factor = 1.0`
+     - Second use: `domain_factor = 0.5`
+     - Third use: `domain_factor = 0.25`
+     - Fourth use: `domain_factor = 0.125`
+     - etc. (formula: `domain_factor = 1 / 2^times_used`)
 
 2. **Per-snippet score**
    ```
    snippet_score = local_score × domain_factor × approved_url_multiplier
    ```
-   `local_score` comes from NLI (entailment + contradiction; see quality model). For **desearch**, `approved_url_multiplier` = 3 when the domain is x.com, twitter.com, reddit.com **or** is in the top-site cache; otherwise 1. For **web**, `approved_url_multiplier` is 3 if the domain is on the dashboard top-site list, else 1.
+   `local_score` comes from NLI (entailment + contradiction; see quality model). For **desearch snippets from x.com, twitter.com, or reddit.com**, `domain_factor` is always 1; for **web snippets** and **desearch from other domains**, `domain_factor` = 1 / 2^times_used for that domain. For **desearch**, `approved_url_multiplier` = 3 when the domain is x.com, twitter.com, reddit.com **or** is in the top-site cache; otherwise 1. For **web**, `approved_url_multiplier` is 3 if the domain is on the dashboard top-site list, else 1.
 
 3. **Aggregation**
    ```
@@ -161,7 +164,9 @@ The desearch adjustment is additive and independent of the speed factor. The soc
 
 2. **Trust desearch URLs, verify URL in body**: Desearch responses are cryptographically signed, so we trust URLs from them (skip blacklist, domain age, SSL, page fetch). We still require the miner's claimed **URL** to appear in at least one signed response body, preventing miners from claiming arbitrary content came from desearch.
 
-3. **NLI and assessment, no excerpt checks**: For desearch we skip statement/excerpt/similarity checks and run only NLI and AI assessment. Snippets are scored on relevance (local_score) and diversity (domain_factor), plus social bonus when applicable.
+3. **NLI and assessment, no excerpt checks**: For desearch we skip statement/excerpt/similarity checks and run only NLI and AI assessment. Snippets are scored on relevance (local_score) and approved_url_multiplier, plus social bonus when applicable.
+
+4. **No duplicate-domain discount for desearch social domains only**: Desearch snippets from x.com, twitter.com, or reddit.com use `domain_factor = 1`. Web snippets (and desearch from other domains) use the domain-diversity penalty (repeated use of the same domain gets 0.5, 0.25, etc.).
 
 ---
 
@@ -170,6 +175,6 @@ The desearch adjustment is additive and independent of the speed factor. The soc
 | File | Change |
 |---|---|
 | `shared/scores.py` | `DESEARCH_PROOF_VALID_BONUS` (+2), `DESEARCH_PROOF_INVALID_PENALTY` (-5), `SOCIAL_BONUS_DOMAIN_X` (+1), `SOCIAL_BONUS_DOMAIN_REDDIT` (+0.5) |
-| `validator/api_server.py` | Miner-level `desearch_adjustment`; per-snippet `snippet_score = local_score × domain_factor × approved_url_multiplier`; **domain diversity**: first use of a domain gets `domain_factor=1.0`, second use `0.5`, third `0.25`, etc. (`1/2^times_used`); social bonus only for desearch snippets when proofs valid |
+| `validator/api_server.py` | Miner-level `desearch_adjustment`; per-snippet `snippet_score = local_score × domain_factor × approved_url_multiplier`; **domain diversity**: **desearch + x.com/twitter.com/reddit.com** use `domain_factor=1`; **web** and **desearch other domains** use first use `domain_factor=1.0`, second `0.5`, etc. (`1/2^times_used`); social bonus only for desearch snippets when proofs valid |
 | `validator/snippet_validator.py` | Desearch: evidence-in-body (URL in body); no statement/excerpt/similarity checks; NLI + AI assessment; **top sites for desearch**: x.com, twitter.com, reddit.com or domain in top_site cache get `approved_url_multiplier` = 3; sets `verify_miner_time_taken_secs` in callees via `_with_verify_time` (always set) |
 | `shared/veridex_protocol.py` | `desearch` as `List[Desearch]`; `desearch_bonus_score` in response |

--- a/docs/desearch-scoring-flow.md
+++ b/docs/desearch-scoring-flow.md
@@ -1,0 +1,166 @@
+# Desearch Scoring & Validation Flow
+
+## Overview
+
+Desearch proof validation and snippet scoring has been refactored into two distinct layers:
+
+1. **Miner-level** -- a single bonus or penalty applied once per miner response based on whether the desearch proofs are valid.
+2. **Snippet-level** -- each snippet with `source_type: "desearch"` skips URL/page-fetch checks (trusting desearch-provided URLs) but still undergoes quality checks and must prove its URL and excerpt exist in the desearch response body.
+
+---
+
+## Constants (`shared/scores.py`)
+
+| Constant | Value | Scope | Description |
+|---|---|---|---|
+| `DESEARCH_PROOF_VALID_BONUS` | +2 | Miner | Added to final score when all desearch proofs verify successfully |
+| `DESEARCH_PROOF_INVALID_PENALTY` | -5 | Miner | Added to final score when any desearch proof fails verification |
+| `SOCIAL_BONUS_DOMAIN_X` | +1 | Per desearch snippet | Added per desearch snippet when domain is x.com or twitter.com |
+| `SOCIAL_BONUS_DOMAIN_REDDIT` | +0.5 | Per desearch snippet | Added per desearch snippet when domain is reddit.com |
+
+---
+
+## Flow Diagram
+
+```
+Miner Response Received
+        |
+        v
+  Desearch proofs provided?
+       / \
+     No   Yes
+      |     |
+      |     v
+      |   Verify every proof (signature, expiry, coldkey binding)
+      |        / \
+      |     Invalid  Valid
+      |       |        |
+      |       v        v
+      |    penalty   bonus
+      |    (-5)      (+2)
+      |       \      /
+      |        v    v
+      +---> desearch_adjustment set
+                |
+                v
+      Validate each snippet concurrently
+                |
+         +------+------+
+         |             |
+   source_type     source_type
+     "web"          "desearch"
+         |             |
+         v             v
+   Full validation   Evidence-in-body check
+   (URL checks,      (URL + excerpt must
+    page fetch,       appear in desearch
+    snippet-in-page,  response body)
+    AI assessment)          |
+         |           +-----+------+
+         |           |            |
+         |        Not found     Found
+         |           |            |
+         |           v            v
+         |     Score: 0       Quality checks only:
+         |     reason:        - excerpt not empty
+         |     "desearch_     - excerpt != statement
+         |      evidence_     - excerpt validity (5+ words)
+         |      not_in_       - similarity to statement
+         |      response"     - context similarity
+         |                    - NLI scoring (entailment/
+         |                      contradiction/neutral)
+         |                          |
+         |                          v
+         |                    snippet_found=True
+         |                    local_score from NLI
+         |                    approved_url_multiplier=1
+         |                    (no page fetch, no AI assessment)
+         |                          |
+         +------------+-------------+
+                      |
+                      v
+         Per-snippet scores aggregated into sum_of_snippets
+                      |
+                      v
+         Social bonus (desearch snippets only, and only when proofs valid): x.com/twitter.com → +1, reddit.com → +0.5
+         Summed into social_bonus_total
+                      |
+                      v
+         final_score = (sum_of_snippets * speed_factor) + desearch_adjustment + social_bonus_total
+```
+
+---
+
+## Detailed Walkthrough
+
+### Step 1: Proof Validation (api_server.py)
+
+When a miner response includes a `desearch` list, the validator:
+
+1. Looks up the miner's **coldkey** from the metagraph.
+2. Iterates over each desearch entry, decoding the base64 response body.
+3. Calls `verify_proof()` for each entry, which:
+   - Checks the proof has not expired.
+   - Reconstructs the signed message: `"{coldkey}|{SHA256(body)}|{timestamp}|{expiry}"`.
+   - Verifies the signature against Desearch's public key.
+4. Sets `desearch_proof_valid = True` only if **all** proofs pass and all bodies are collected.
+
+### Step 2: Snippet Validation (snippet_validator.py)
+
+Each snippet is validated concurrently. When `source_type == "desearch"`:
+
+**What is checked:**
+- The snippet's URL must be found in at least one of the decoded desearch response bodies (`_evidence_in_desearch_response`); the excerpt is not checked.
+- Excerpt is not empty (`NO_SNIPPET_PROVIDED`, score: -5).
+- Excerpt is not identical to the original statement (`SNIPPET_SAME_AS_STATEMENT`, score: -10).
+- Excerpt passes validity check -- at least 5 words (`INVALID_SNIPPET_EXCERPT`, score: -5).
+- Excerpt is not too semantically similar to the statement (`EXCERPT_TOO_SIMILAR`, score: -5).
+- Context similarity score is computed (statement vs excerpt).
+- NLI scoring via `score_statement_distribution` produces `local_score` and entailment/contradiction/neutral probabilities.
+
+**What is skipped (compared to `source_type: "web"`):**
+- SSL / HTTPS enforcement
+- Domain blacklist check
+- Domain age check (recently registered)
+- Search URL detection (query params, `/search/` path)
+- Page fetching (HTTP + Selenium)
+- Snippet-in-page verification (fuzzy matching against fetched page text)
+- Approved URL multiplier (hardcoded to 1 for desearch)
+
+**What is run (same as web for signal values):**
+- AI statement assessment (`assess_statement_async`) is called with the excerpt as webpage context (no full page fetch), so desearch snippets get the same signal fields: sentiment, conviction, source_credibility, narrative_momentum, risk_reward_sentiment, catalyst_detection, political_leaning, and `assess_statement_time_taken_secs` is populated.
+
+### Step 3: Final Score Calculation (api_server.py)
+
+```
+final_score = (sum_of_snippets * speed_factor) + desearch_adjustment + social_bonus_total
+```
+
+Where:
+- `sum_of_snippets` = sum of all per-snippet scores (including domain diversity factor)
+- `speed_factor` = miner response time factor
+- `desearch_adjustment` = `+2` if proofs valid, `-5` if proofs invalid, `0` if no desearch proofs provided
+- `social_bonus_total` = sum of per-snippet social bonus **for desearch snippets only and only when desearch proofs are valid**: +1 per snippet from x.com or twitter.com, +0.5 per snippet from reddit.com; web snippets do not receive social bonus. If proofs are invalid or absent, no social bonus is applied.
+
+The desearch adjustment is additive and independent of the speed factor -- it rewards miners for providing cryptographically verifiable evidence or penalizes them for submitting invalid proofs. The social bonus rewards desearch snippets from social domains (X, Reddit) on top of the base snippet and desearch proof scoring.
+
+---
+
+## Key Design Decisions
+
+1. **Miner-level, not per-snippet**: The desearch proof bonus/penalty is applied once per miner response rather than per snippet. This prevents miners from inflating scores by submitting many desearch snippets, while still rewarding the use of verifiable sources.
+
+2. **Trust desearch URLs, verify content**: Since desearch responses are cryptographically signed by the Desearch API, we trust that the URLs within them are legitimate (skip blacklist, domain age, SSL, page fetch). However, we still verify that the miner's claimed URL and excerpt actually appear in the signed response body -- preventing miners from submitting arbitrary content and claiming it came from desearch.
+
+3. **Quality checks still apply**: Even with trusted URLs, snippet quality checks (empty excerpt, same-as-statement, excerpt validity, similarity, NLI scoring) still run. This ensures desearch snippets are scored on their relevance and quality, not just their provenance.
+
+---
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `shared/scores.py` | Replaced `DESEARCH_SNIPPET_BONUS`, `DESEARCH_PROOF_INVALID`, `DESEARCH_PROOF_EXPIRED` with `DESEARCH_PROOF_VALID_BONUS` (+2) and `DESEARCH_PROOF_INVALID_PENALTY` (-5) |
+| `validator/api_server.py` | Removed per-snippet desearch bonus from scoring loop; added miner-level `desearch_adjustment` to final score; removed `desearch_proof_valid` from snippet task calls |
+| `validator/snippet_validator.py` | Removed `desearch_proof_valid` parameter; replaced short-circuit return with evidence-in-body check followed by full quality checks; removed `DESEARCH_SNIPPET_BONUS` usage |
+| `shared/veridex_protocol.py` | Renamed `desearch_bonus` to `desearch_bonus_score`; updated to `Optional[List[Desearch]]` default |

--- a/docs/desearch-scoring-flow.md
+++ b/docs/desearch-scoring-flow.md
@@ -15,6 +15,7 @@ Desearch proof validation and snippet scoring has been refactored into two disti
 |---|---|---|---|
 | `DESEARCH_PROOF_VALID_BONUS` | +2 | Miner | Added to final score when all desearch proofs verify successfully |
 | `DESEARCH_PROOF_INVALID_PENALTY` | -5 | Miner | Added to final score when any desearch proof fails verification |
+| `DESEARCH_EVIDENCE_NOT_IN_RESPONSE` | -1 | Per desearch snippet | Snippet score when URL is not found in any desearch response body (`snippet_found=False`, reason `desearch_evidence_not_in_response`) |
 | `SOCIAL_BONUS_DOMAIN_X` | +1 | Per desearch snippet | Added per desearch snippet when domain is x.com or twitter.com |
 | `SOCIAL_BONUS_DOMAIN_REDDIT` | +0.5 | Per desearch snippet | Added per desearch snippet when domain is reddit.com |
 | `APPROVED_URL_MULTIPLIER` | 3 | Per snippet | For desearch, x.com / twitter.com / reddit.com **or** any domain in the top-site cache get this multiplier; other desearch domains get 1. For web, only top-site cache is used. |
@@ -69,6 +70,8 @@ Miner Response Received
          |      evidence_
          |      not_in_
          |      response"
+         |     snippet_score=-1
+         |     (DESEARCH_EVIDENCE_NOT_IN_RESPONSE)
          |                    NLI + AI assessment →
          |                    snippet_found=True, local_score,
          |                    approved_url_multiplier=3 for x.com/twitter/reddit or top_site cache, else 1

--- a/docs/desearch-scoring-flow.md
+++ b/docs/desearch-scoring-flow.md
@@ -5,7 +5,7 @@
 Desearch proof validation and snippet scoring has been refactored into two distinct layers:
 
 1. **Miner-level** -- a single bonus or penalty applied once per miner response based on whether the desearch proofs are valid.
-2. **Snippet-level** -- each snippet with `source_type: "desearch"` skips URL/page-fetch checks (trusting desearch-provided URLs) but still undergoes quality checks and must prove its URL and excerpt exist in the desearch response body.
+2. **Snippet-level** -- each snippet with `source_type: "desearch"` skips URL/page-fetch checks (trusting desearch-provided URLs) but must prove its **URL** appears in at least one desearch response body; then NLI and AI assessment run (no statement/excerpt/similarity checks).
 
 ---
 
@@ -17,6 +17,7 @@ Desearch proof validation and snippet scoring has been refactored into two disti
 | `DESEARCH_PROOF_INVALID_PENALTY` | -5 | Miner | Added to final score when any desearch proof fails verification |
 | `SOCIAL_BONUS_DOMAIN_X` | +1 | Per desearch snippet | Added per desearch snippet when domain is x.com or twitter.com |
 | `SOCIAL_BONUS_DOMAIN_REDDIT` | +0.5 | Per desearch snippet | Added per desearch snippet when domain is reddit.com |
+| `APPROVED_URL_MULTIPLIER` | 3 | Per snippet | For desearch, x.com / twitter.com / reddit.com **or** any domain in the top-site cache get this multiplier; other desearch domains get 1. For web, only top-site cache is used. |
 
 ---
 
@@ -52,41 +53,40 @@ Miner Response Received
          |             |
          v             v
    Full validation   Evidence-in-body check
-   (URL checks,      (URL + excerpt must
-    page fetch,       appear in desearch
-    snippet-in-page,  response body)
-    AI assessment)          |
+   (URL checks,      (snippet URL must appear
+    page fetch,       in at least one desearch
+    snippet-in-page,  response body; excerpt
+    AI assessment)    not checked in body)
          |           +-----+------+
          |           |            |
          |        Not found     Found
          |           |            |
          |           v            v
-         |     Score: 0       Quality checks only:
-         |     reason:        - excerpt not empty
-         |     "desearch_     - excerpt != statement
-         |      evidence_     - excerpt validity (5+ words)
-         |      not_in_       - similarity to statement
-         |      response"     - context similarity
-         |                    - NLI scoring (entailment/
-         |                      contradiction/neutral)
-         |                          |
-         |                          v
-         |                    snippet_found=True
-         |                    local_score from NLI
-         |                    approved_url_multiplier=1
-         |                    (no page fetch, no AI assessment)
+         |     snippet_found   NLI + AI assessment
+         |     =False,         only (no statement/
+         |     reason:         excerpt/similarity
+         |     "desearch_      validation)
+         |      evidence_
+         |      not_in_
+         |      response"
+         |                    NLI + AI assessment →
+         |                    snippet_found=True, local_score,
+         |                    approved_url_multiplier=3 for x.com/twitter/reddit or top_site cache, else 1
          |                          |
          +------------+-------------+
                       |
                       v
-         Per-snippet scores aggregated into sum_of_snippets
+         For each snippet_found: domain_factor = 1/2^times_used (1st use=1.0, 2nd=0.5, 3rd=0.25, ...)
+         snippet_score = local_score × domain_factor × approved_url_multiplier
                       |
                       v
-         Social bonus (desearch snippets only, and only when proofs valid): x.com/twitter.com → +1, reddit.com → +0.5
-         Summed into social_bonus_total
+         sum_of_snippets = sum of all snippet_score
                       |
                       v
-         final_score = (sum_of_snippets * speed_factor) + desearch_adjustment + social_bonus_total
+         Social bonus (desearch only, when proofs valid): x.com/twitter.com → +1, reddit.com → +0.5 → social_bonus_total
+                      |
+                      v
+         final_score = (sum_of_snippets × speed_factor) + desearch_adjustment + social_bonus_total
 ```
 
 ---
@@ -110,39 +110,48 @@ When a miner response includes a `desearch` list, the validator:
 Each snippet is validated concurrently. When `source_type == "desearch"`:
 
 **What is checked:**
-- The snippet's URL must be found in at least one of the decoded desearch response bodies (`_evidence_in_desearch_response`); the excerpt is not checked.
-- Excerpt is not empty (`NO_SNIPPET_PROVIDED`, score: -5).
-- Excerpt is not identical to the original statement (`SNIPPET_SAME_AS_STATEMENT`, score: -10).
-- Excerpt passes validity check -- at least 5 words (`INVALID_SNIPPET_EXCERPT`, score: -5).
-- Excerpt is not too semantically similar to the statement (`EXCERPT_TOO_SIMILAR`, score: -5).
-- Context similarity score is computed (statement vs excerpt).
+- The snippet's **URL** must be found in at least one of the decoded desearch response bodies (`_evidence_in_desearch_response`). The excerpt is not checked against the response body.
+- If the URL is not found, the snippet fails with `desearch_evidence_not_in_response` (score: -1).
 - NLI scoring via `score_statement_distribution` produces `local_score` and entailment/contradiction/neutral probabilities.
+- AI statement assessment (`assess_statement_async`) is run with the excerpt as context to populate signals (sentiment, conviction, etc.).
 
 **What is skipped (compared to `source_type: "web"`):**
-- SSL / HTTPS enforcement
-- Domain blacklist check
-- Domain age check (recently registered)
-- Search URL detection (query params, `/search/` path)
-- Page fetching (HTTP + Selenium)
-- Snippet-in-page verification (fuzzy matching against fetched page text)
-- Approved URL multiplier (hardcoded to 1 for desearch)
-
-**What is run (same as web for signal values):**
-- AI statement assessment (`assess_statement_async`) is called with the excerpt as webpage context (no full page fetch), so desearch snippets get the same signal fields: sentiment, conviction, source_credibility, narrative_momentum, risk_reward_sentiment, catalyst_detection, political_leaning, and `assess_statement_time_taken_secs` is populated.
+- Statement/excerpt checks (empty excerpt, same-as-statement, excerpt validity, excerpt-too-similar).
+- Context similarity and statement similarity (set to 0 for desearch).
+- Domain blacklist check, domain age check, search URL detection.
+- Page fetching (HTTP + Selenium) and snippet-in-page verification.
+- **Top sites for desearch**: x.com, twitter.com, and reddit.com are always treated as approved (top) sites; **and** any domain in the top-site cache (dashboard) also counts as approved. Approved domains get `approved_url_multiplier` = 3; others get 1. (Web uses only the top-site cache.)
 
 ### Step 3: Final Score Calculation (api_server.py)
 
-```
-final_score = (sum_of_snippets * speed_factor) + desearch_adjustment + social_bonus_total
-```
+Snippets are processed in order. For each response with `snippet_found=True`:
+
+1. **Domain diversity factor**  
+   For each domain, we track how many times it has been used so far in this response. The first snippet from a domain gets no penalty; repeated use of the same domain is discounted:
+   - First use of domain: `domain_factor = 1.0`
+   - Second use: `domain_factor = 0.5`
+   - Third use: `domain_factor = 0.25`
+   - Fourth use: `domain_factor = 0.125`
+   - etc. (formula: `domain_factor = 1 / 2^times_used`)
+
+2. **Per-snippet score**
+   ```
+   snippet_score = local_score × domain_factor × approved_url_multiplier
+   ```
+   `local_score` comes from NLI (entailment + contradiction; see quality model). For **desearch**, `approved_url_multiplier` = 3 when the domain is x.com, twitter.com, reddit.com **or** is in the top-site cache; otherwise 1. For **web**, `approved_url_multiplier` is 3 if the domain is on the dashboard top-site list, else 1.
+
+3. **Aggregation**
+   ```
+   sum_of_snippets = sum of snippet_score over all snippets (including those with snippet_found=False, which contribute 0)
+   final_score = (sum_of_snippets × speed_factor) + desearch_adjustment + social_bonus_total
+   ```
 
 Where:
-- `sum_of_snippets` = sum of all per-snippet scores (including domain diversity factor)
-- `speed_factor` = miner response time factor
-- `desearch_adjustment` = `+2` if proofs valid, `-5` if proofs invalid, `0` if no desearch proofs provided
-- `social_bonus_total` = sum of per-snippet social bonus **for desearch snippets only and only when desearch proofs are valid**: +1 per snippet from x.com or twitter.com, +0.5 per snippet from reddit.com; web snippets do not receive social bonus. If proofs are invalid or absent, no social bonus is applied.
+- `speed_factor` = miner response time factor (e.g. 1.0 for normal latency).
+- `desearch_adjustment` = `+2` if desearch proofs valid, `-5` if any proof invalid, `0` if no desearch proofs provided.
+- `social_bonus_total` = sum of per-snippet social bonus **for desearch snippets only and only when desearch proofs are valid**: +1 per snippet from x.com or twitter.com, +0.5 per snippet from reddit.com. Web snippets do not receive social bonus.
 
-The desearch adjustment is additive and independent of the speed factor -- it rewards miners for providing cryptographically verifiable evidence or penalizes them for submitting invalid proofs. The social bonus rewards desearch snippets from social domains (X, Reddit) on top of the base snippet and desearch proof scoring.
+The desearch adjustment is additive and independent of the speed factor. The social bonus rewards desearch snippets from social domains (X, Reddit) on top of the base snippet and desearch proof scoring.
 
 ---
 
@@ -150,9 +159,9 @@ The desearch adjustment is additive and independent of the speed factor -- it re
 
 1. **Miner-level, not per-snippet**: The desearch proof bonus/penalty is applied once per miner response rather than per snippet. This prevents miners from inflating scores by submitting many desearch snippets, while still rewarding the use of verifiable sources.
 
-2. **Trust desearch URLs, verify content**: Since desearch responses are cryptographically signed by the Desearch API, we trust that the URLs within them are legitimate (skip blacklist, domain age, SSL, page fetch). However, we still verify that the miner's claimed URL and excerpt actually appear in the signed response body -- preventing miners from submitting arbitrary content and claiming it came from desearch.
+2. **Trust desearch URLs, verify URL in body**: Desearch responses are cryptographically signed, so we trust URLs from them (skip blacklist, domain age, SSL, page fetch). We still require the miner's claimed **URL** to appear in at least one signed response body, preventing miners from claiming arbitrary content came from desearch.
 
-3. **Quality checks still apply**: Even with trusted URLs, snippet quality checks (empty excerpt, same-as-statement, excerpt validity, similarity, NLI scoring) still run. This ensures desearch snippets are scored on their relevance and quality, not just their provenance.
+3. **NLI and assessment, no excerpt checks**: For desearch we skip statement/excerpt/similarity checks and run only NLI and AI assessment. Snippets are scored on relevance (local_score) and diversity (domain_factor), plus social bonus when applicable.
 
 ---
 
@@ -160,7 +169,7 @@ The desearch adjustment is additive and independent of the speed factor -- it re
 
 | File | Change |
 |---|---|
-| `shared/scores.py` | Replaced `DESEARCH_SNIPPET_BONUS`, `DESEARCH_PROOF_INVALID`, `DESEARCH_PROOF_EXPIRED` with `DESEARCH_PROOF_VALID_BONUS` (+2) and `DESEARCH_PROOF_INVALID_PENALTY` (-5) |
-| `validator/api_server.py` | Removed per-snippet desearch bonus from scoring loop; added miner-level `desearch_adjustment` to final score; removed `desearch_proof_valid` from snippet task calls |
-| `validator/snippet_validator.py` | Removed `desearch_proof_valid` parameter; replaced short-circuit return with evidence-in-body check followed by full quality checks; removed `DESEARCH_SNIPPET_BONUS` usage |
-| `shared/veridex_protocol.py` | Renamed `desearch_bonus` to `desearch_bonus_score`; updated to `Optional[List[Desearch]]` default |
+| `shared/scores.py` | `DESEARCH_PROOF_VALID_BONUS` (+2), `DESEARCH_PROOF_INVALID_PENALTY` (-5), `SOCIAL_BONUS_DOMAIN_X` (+1), `SOCIAL_BONUS_DOMAIN_REDDIT` (+0.5) |
+| `validator/api_server.py` | Miner-level `desearch_adjustment`; per-snippet `snippet_score = local_score × domain_factor × approved_url_multiplier`; **domain diversity**: first use of a domain gets `domain_factor=1.0`, second use `0.5`, third `0.25`, etc. (`1/2^times_used`); social bonus only for desearch snippets when proofs valid |
+| `validator/snippet_validator.py` | Desearch: evidence-in-body (URL in body); no statement/excerpt/similarity checks; NLI + AI assessment; **top sites for desearch**: x.com, twitter.com, reddit.com or domain in top_site cache get `approved_url_multiplier` = 3; sets `verify_miner_time_taken_secs` in callees via `_with_verify_time` (always set) |
+| `shared/veridex_protocol.py` | `desearch` as `List[Desearch]`; `desearch_bonus_score` in response |

--- a/docs/miner_rejection_and_snippet_reasons.md
+++ b/docs/miner_rejection_and_snippet_reasons.md
@@ -103,11 +103,14 @@ In addition to the fields in section 2, each snippet response includes:
 
 - **Legacy (top-level):** `verify_miner_time_taken_secs`, `fetch_page_time_taken_secs`, `assess_statement_time_taken_secs`, `snippet_fetcher_http_time_secs`, `snippet_fetcher_selenium_time_secs`, `snippet_fetcher_total_time_secs`, `cleaning_html_time_taken_secs`, `fetch_by_http_status`, `fetch_by_selenium_status`.
 - **timing:** `StatementResponseTiming` — same values as above, plus all timing/status in one object. Use `timing.fetch_by_http_status` / `timing.fetch_by_selenium_status` and `timing.cleaning_html_time_taken_secs` for fetch-by-HTTP/Selenium status and cleaning_html timing.
+- **social_bonus_contribution:** Per-excerpt contribution to the miner’s social bonus. `0` for web snippets or when desearch proofs are invalid; `1.0` for a desearch snippet from x.com/twitter.com; `0.5` for a desearch snippet from reddit.com (only when proofs are valid). The miner’s `social_bonus_score` is the sum of this field across all snippets.
 
 ### VericoreMinerStatementResponse (per-miner)
 
 - **Legacy (top-level):** `elapsed_time`, `total_fetch_time_secs`, `total_ai_time_secs`, `total_other_time_secs`, `avg_snippet_time_secs`, `max_snippet_time_secs`, `snippet_count`.
 - **timing:** `MinerResponseTiming` — same aggregated timing in one object.
+- **desearch_bonus_score:** Miner-level desearch proof bonus or penalty. `+2` when all desearch proofs verify successfully, `-5` when any proof fails, `0` when no desearch proofs are provided.
+- **social_bonus_score:** Sum of per-snippet social bonus for **desearch** snippets only, and only when desearch proofs are valid. `+1` per snippet from x.com or twitter.com, `+0.5` per snippet from reddit.com; web snippets do not contribute. If proofs are invalid or absent, this is 0. Added to `final_score` along with `desearch_bonus_score`.
 
 ### VericoreQueryResponse (per-query)
 

--- a/docs/scoring_mechanics_subnet_70.md
+++ b/docs/scoring_mechanics_subnet_70.md
@@ -46,9 +46,13 @@ Miners receive penalties for various validation failures:
 
 #### Validation Bonuses
 
-| Bonus Type | Multiplier | Description |
-|------------|------------|-------------|
+| Bonus Type | Value | Description |
+|------------|--------|-------------|
 | Approved URL Multiplier | 3x | Evidence comes from pre-approved, high-quality domains |
+| Desearch proof valid | +2 | Miner-level: all desearch proofs verify successfully (applied once per response) |
+| Desearch proof invalid | -5 | Miner-level: any desearch proof fails verification |
+| Social bonus (desearch only, proofs valid) | +1 per snippet | Desearch snippet from x.com or twitter.com; only when desearch proofs verify |
+| Social bonus (desearch only, proofs valid) | +0.5 per snippet | Desearch snippet from reddit.com; only when desearch proofs verify |
 
 ### 2. Miner Response Aggregation
 
@@ -66,7 +70,9 @@ For each miner response, the scoring process is:
 2. **Individual snippet scoring**: Each snippet gets validated and scored
 3. **Domain deduplication**: Penalize repeated use of same domain within response
 4. **Speed factor application**: Response time bonus/penalty
-5. **Final aggregation**: Combine all factors into final_score
+5. **Desearch adjustment**: Miner-level +2 (all proofs valid) or -5 (any invalid) or 0 (no desearch)
+6. **Social bonus**: Per desearch snippet only, and only when desearch proofs are valid — +1 for x.com/twitter.com, +0.5 for reddit.com
+7. **Final aggregation**: Combine all factors into final_score
 
 **Formula per miner:**
 ```
@@ -82,8 +88,12 @@ sum_of_snippets = Σ(snippet_score for all valid snippets)
 # Step 4: Apply speed factor
 speed_factor = max(1, 2.0 - (response_time_seconds / 30.0))
 
-# Step 5: Final score for ranking
-final_score = sum_of_snippets × speed_factor
+# Step 5: Desearch adjustment (miner-level) and social bonus (desearch snippets only, proofs valid)
+desearch_adjustment = +2 if all desearch proofs valid, -5 if any invalid, 0 if no desearch proofs
+social_bonus_total = Σ(+1 for desearch snippet from x.com/twitter.com, +0.5 for reddit.com; 0 for web or if proofs invalid)
+
+# Step 6: Final score for ranking
+final_score = (sum_of_snippets × speed_factor) + desearch_adjustment + social_bonus_total
 ```
 
 **Speed Factor Details:**

--- a/miner/README.md
+++ b/miner/README.md
@@ -155,6 +155,39 @@ or on Windows
 $env:PERPLEXICA_URL="<your_perplexica_url>"
 ```
 
+#### Desearch Miner
+
+**Desearch** can be used as a search source. Miners receive a bonus per verified Desearch snippet. You must bind your miner coldkey to your Desearch account and use the Desearch API with proof headers.
+
+- **API reference for miners:** [https://desearch.ai/docs/api-reference](https://desearch.ai/docs/api-reference)
+- **Environment variables:** Set `DESEARCH_API_KEY` (required). Optionally set `DESEARCH_BASE_URL` (default `https://api.desearch.ai`).
+
+**Coldkey binding (required):** Miners must bind their Bittensor coldkey to their Desearch account (similar to SN6). The validator uses the miner's coldkey from the metagraph to verify proof; if you use another miner's coldkey in requests, the signature will not match. To bind: register on Desearch with an email, then run the one-time link (see below). After linking, all API calls are tied to that coldkey.
+
+**One-time link (bind coldkey to Desearch account):** POST to `https://api.desearch.ai/bt/miner/link` with your API key and a signature of the API key with your coldkey private key:
+
+```python
+import requests
+from bittensor_wallet import Wallet
+
+API_KEY = "YOUR_DESEARCH_API_KEY"
+WALLET_NAME = "my_wallet"
+WALLET_PASSWORD = "my_password"
+
+wallet = Wallet(name=WALLET_NAME)
+keypair = wallet.get_coldkey(WALLET_PASSWORD)
+coldkey_ss58 = keypair.ss58_address
+
+signature_bytes = keypair.sign(API_KEY.encode("utf-8"))
+signature_hex = signature_bytes.hex()
+
+headers = {"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"}
+payload = {"coldkey_ss58": coldkey_ss58, "signature_hex": signature_hex}
+response = requests.post("https://api.desearch.ai/bt/miner/link", json=payload, headers=headers)
+```
+
+**Request headers when calling Desearch:** Use `Authorization: Bearer <API_KEY>` and `X-Coldkey: <your_coldkey_ss58>`. The response includes proof headers: `X-Proof-Signature`, `X-Proof-Timestamp`, `X-Proof-Expiry`. The example miner in `miner/desearch/miner.py` sets `synapse.desearch` from the response body (base64) and these headers, and builds evidence with `source_type="desearch"`.
+
 ## Running the Miner
 
 In one terminal window, navigate to the project directory and run:

--- a/miner/README.md
+++ b/miner/README.md
@@ -164,7 +164,13 @@ $env:PERPLEXICA_URL="<your_perplexica_url>"
 
 **Coldkey binding (required):** Miners must bind their Bittensor coldkey to their Desearch account (similar to SN6). The validator uses the miner's coldkey from the metagraph to verify proof; if you use another miner's coldkey in requests, the signature will not match. To bind: register on Desearch with an email, then run the one-time link (see below). After linking, all API calls are tied to that coldkey.
 
-**One-time link (bind coldkey to Desearch account):** POST to `https://api.desearch.ai/bt/miner/link` with your API key and a signature of the API key with your coldkey private key:
+**One-time link (bind coldkey to Desearch account):** Run from repo root with `DESEARCH_API_KEY` set. Put coldkey password in `WALLET_PASSWORD` or `DESEARCH_WALLET_PASSWORD` (or pass `--wallet.password`):
+
+```bash
+python -m utils.link_desearch_miner --wallet.name my_wallet --wallet.hotkey miner_desearch_hotkey
+```
+
+Or POST to `https://api.desearch.ai/bt/miner/link` with your API key and a signature of the API key with your coldkey private key:
 
 ```python
 import requests
@@ -187,6 +193,8 @@ response = requests.post("https://api.desearch.ai/bt/miner/link", json=payload, 
 ```
 
 **Request headers when calling Desearch:** Use `Authorization: Bearer <API_KEY>` and `X-Coldkey: <your_coldkey_ss58>`. The response includes proof headers: `X-Proof-Signature`, `X-Proof-Timestamp`, `X-Proof-Expiry`. The example miner in `miner/desearch/miner.py` sets `synapse.desearch` from the response body (base64) and these headers, and builds evidence with `source_type="desearch"`.
+
+**Test miner → verify flow:** From repo root, run `python -m utils.test_desearch_verify` (with `DESEARCH_API_KEY` set). This calls Desearch with a test coldkey, gets response + proof, and runs the same `verify_proof` logic the validator uses. Default test coldkey: `5CdQ3YfmGPJojVahShC2EyT9rUmThecZQiiLquDKVNYCGhbX` (override with `--coldkey`). For full miner run then verify, use `python -m utils.validate_desearch_signature --coldkey <SS58>`.
 
 ## Running the Miner
 

--- a/miner/README.md
+++ b/miner/README.md
@@ -162,7 +162,7 @@ $env:PERPLEXICA_URL="<your_perplexica_url>"
 - **API reference for miners:** [https://desearch.ai/docs/api-reference](https://desearch.ai/docs/api-reference)
 - **Environment variables:** Set `DESEARCH_API_KEY` (required). Optionally set `DESEARCH_BASE_URL` (default `https://api.desearch.ai`).
 
-**Coldkey binding (required):** Miners must bind their Bittensor coldkey to their Desearch account (similar to SN6). The validator uses the miner's coldkey from the metagraph to verify proof; if you use another miner's coldkey in requests, the signature will not match. To bind: register on Desearch with an email, then run the one-time link (see below). After linking, all API calls are tied to that coldkey.
+**Coldkey binding (required):** Miners must bind their Bittensor coldkey to their Desearch account. The validator uses the miner's coldkey from the metagraph to verify proof; if you use another miner's coldkey in requests, the signature will not match. To bind: register on Desearch with an email, then run the one-time link (see below). After linking, all API calls are tied to that coldkey.
 
 **One-time link (bind coldkey to Desearch account):** Run from repo root with `DESEARCH_API_KEY` set. Put coldkey password in `WALLET_PASSWORD` or `DESEARCH_WALLET_PASSWORD` (or pass `--wallet.password`):
 
@@ -187,12 +187,12 @@ coldkey_ss58 = keypair.ss58_address
 signature_bytes = keypair.sign(API_KEY.encode("utf-8"))
 signature_hex = signature_bytes.hex()
 
-headers = {"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"}
+headers = {"Authorization": API_KEY, "Content-Type": "application/json"}
 payload = {"coldkey_ss58": coldkey_ss58, "signature_hex": signature_hex}
 response = requests.post("https://api.desearch.ai/bt/miner/link", json=payload, headers=headers)
 ```
 
-**Request headers when calling Desearch:** Use `Authorization: Bearer <API_KEY>` and `X-Coldkey: <your_coldkey_ss58>`. The response includes proof headers: `X-Proof-Signature`, `X-Proof-Timestamp`, `X-Proof-Expiry`. The example miner in `miner/desearch/miner.py` sets `synapse.desearch` from the response body (base64) and these headers, and builds evidence with `source_type="desearch"`.
+**Request headers when calling Desearch:** Use `Authorization: <API_KEY>` (raw API key, no Bearer prefix) and `X-Coldkey: <your_coldkey_ss58>`. The response includes proof headers: `X-Proof-Signature`, `X-Proof-Timestamp`, `X-Proof-Expiry`. The example miner in `miner/desearch/miner.py` sets `synapse.desearch` from the response body (base64) and these headers, and builds evidence with `source_type="desearch"`.
 
 **Test miner → verify flow:** From repo root, run `python -m utils.test_desearch_verify` (with `DESEARCH_API_KEY` set). This calls Desearch with a test coldkey, gets response + proof, and runs the same `verify_proof` logic the validator uses. Default test coldkey: `5CdQ3YfmGPJojVahShC2EyT9rUmThecZQiiLquDKVNYCGhbX` (override with `--coldkey`). For full miner run then verify, use `python -m utils.validate_desearch_signature --coldkey <SS58>`.
 

--- a/miner/desearch/miner.py
+++ b/miner/desearch/miner.py
@@ -1,0 +1,230 @@
+"""
+Example miner that uses Desearch API and attaches proof to the synapse.
+
+Requires:
+- DESEARCH_API_KEY: your Desearch API key (set in env).
+- Miner coldkey must be linked to your Desearch account (one-time: POST to /bt/miner/link).
+See https://desearch.ai/docs/api-reference and miner README for linking and usage.
+"""
+import argparse
+import base64
+import json
+import os
+import time
+import traceback
+from typing import Tuple, List
+
+import bittensor as bt
+import requests
+
+from dotenv import load_dotenv
+
+from shared.log_data import LoggerType
+from shared.proxy_log_handler import register_proxy_log_handler
+from shared.veridex_protocol import (
+    VericoreSynapse,
+    SourceEvidence,
+    Desearch,
+    DesearchProof,
+)
+from shared.environment_variables import DESEARCH_API_KEY, DESEARCH_BASE_URL
+
+# When set (e.g. by utils.validate_desearch_signature), use this coldkey and skip wallet/subtensor/registration.
+DESEARCH_COLDKEY_SS58_ENV = os.environ.get("DESEARCH_COLDKEY_SS58", "").strip()
+
+bt.logging.set_trace()
+load_dotenv()
+
+# Desearch search endpoint (adjust if API differs)
+DESEARCH_SEARCH_PATH = "/search"
+
+
+class Miner:
+    def __init__(self):
+        self.config = self.get_config()
+        self.setup_bittensor_objects()
+        self.setup_logging()
+
+        if not DESEARCH_API_KEY:
+            bt.logging.warning(
+                "DESEARCH_API_KEY not set. Set it in env to use the Desearch miner."
+            )
+
+    def get_config(self):
+        if DESEARCH_COLDKEY_SS58_ENV:
+            parser = argparse.ArgumentParser()
+            parser.add_argument("--netuid", type=int, default=1, help="Subnet UID.")
+            bt.logging.add_args(parser)
+            config = parser.parse_args()
+            log_dir = getattr(config, "logging_dir", os.path.expanduser("~/.bittensor/miner"))
+            config.full_path = os.path.join(os.path.abspath(log_dir), "desearch_validate")
+            os.makedirs(config.full_path, exist_ok=True)
+            return config
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--netuid", type=int, default=1, help="Subnet UID.")
+        bt.subtensor.add_args(parser)
+        bt.logging.add_args(parser)
+        bt.wallet.add_args(parser)
+        bt.axon.add_args(parser)
+        config = bt.config(parser)
+        config.full_path = os.path.expanduser(
+            "{}/{}/{}/netuid{}/{}".format(
+                config.logging.logging_dir,
+                config.wallet.name,
+                config.wallet.hotkey_str,
+                config.netuid,
+                "miner",
+            )
+        )
+        os.makedirs(config.full_path, exist_ok=True)
+        return config
+
+    def setup_logging(self):
+        bt.logging(config=self.config, logging_dir=self.config.full_path)
+
+    def setup_proxy_logger(self):
+        bt_logger = __import__("logging").getLogger("bittensor")
+        register_proxy_log_handler(bt_logger, LoggerType.Miner, self.wallet)
+
+    def setup_bittensor_objects(self):
+        if DESEARCH_COLDKEY_SS58_ENV:
+            self.wallet = None
+            self.subtensor = None
+            self.metagraph = None
+            self.my_subnet_uid = -1
+            self.coldkey_ss58 = DESEARCH_COLDKEY_SS58_ENV
+            return
+        self.wallet = bt.wallet(config=self.config)
+        self.subtensor = bt.subtensor(config=self.config)
+        self.metagraph = self.subtensor.metagraph(self.config.netuid)
+        if self.wallet.hotkey.ss58_address not in self.metagraph.hotkeys:
+            bt.logging.error("Miner not registered. Run btcli register.")
+            exit()
+        self.my_subnet_uid = self.metagraph.hotkeys.index(
+            self.wallet.hotkey.ss58_address
+        )
+        # Coldkey SS58 for Desearch requests (validator uses same from metagraph to verify)
+        self.coldkey_ss58 = ""
+        if hasattr(self.wallet, "coldkeypub") and self.wallet.coldkeypub is not None:
+            self.coldkey_ss58 = getattr(self.wallet.coldkeypub, "ss58_address", "") or ""
+
+    def blacklist_fn(self, synapse: VericoreSynapse) -> Tuple[bool, str]:
+        if self.metagraph is None:
+            return True, None
+        if synapse.dendrite.hotkey not in self.metagraph.hotkeys:
+            return True, None
+        try:
+            neuron_uid = self.metagraph.hotkeys.index(synapse.dendrite.hotkey)
+            neuron = self.metagraph.neurons[neuron_uid]
+            if not neuron.validator_permit:
+                return True, None
+            if neuron.axon_info is None or not neuron.axon_info.is_serving:
+                return True, None
+            return False, None
+        except (ValueError, IndexError):
+            return True, None
+
+    def call_desearch(self, statement: str) -> tuple[bytes, str, str, str] | None:
+        """
+        Call Desearch API once. Returns (response_body_bytes, signature_hex, timestamp, expiry) or None.
+        """
+        if not DESEARCH_API_KEY or not self.coldkey_ss58:
+            return None
+        url = f"{DESEARCH_BASE_URL.rstrip('/')}{DESEARCH_SEARCH_PATH}"
+        headers = {
+            "Authorization": f"Bearer {DESEARCH_API_KEY}",
+            "X-Coldkey": self.coldkey_ss58,
+            "Content-Type": "application/json",
+        }
+        try:
+            resp = requests.post(
+                url,
+                json={"query": statement},
+                headers=headers,
+                timeout=60,
+            )
+            body_bytes = resp.content
+            sig = resp.headers.get("X-Proof-Signature", "")
+            ts = resp.headers.get("X-Proof-Timestamp", "")
+            exp = resp.headers.get("X-Proof-Expiry", "")
+            return (body_bytes, sig, ts, exp)
+        except Exception as e:
+            bt.logging.warning(f"Desearch API call failed: {e}")
+            return None
+
+    def veridex_forward(self, synapse: VericoreSynapse) -> VericoreSynapse:
+        bt.logging.info(f"{synapse.request_id} | Received Vericore request")
+        statement = synapse.statement
+        synapse.veridex_response = []
+
+        result = self.call_desearch(statement)
+        if not result:
+            bt.logging.info(f"{synapse.request_id} | No Desearch response, returning empty")
+            return synapse
+
+        body_bytes, signature_hex, timestamp, expiry = result
+        if not (signature_hex and timestamp and expiry):
+            bt.logging.warning(f"{synapse.request_id} | Desearch response missing proof headers")
+            return synapse
+
+        # Set proof on root (body base64 + proof from headers)
+        synapse.desearch = Desearch(
+            response_body=base64.b64encode(body_bytes).decode("ascii"),
+            proof=DesearchProof(
+                signature=signature_hex,
+                timestamp=timestamp,
+                expiry=expiry,
+            ),
+        )
+
+        # Parse response and build evidence (assume JSON list of {url, snippet})
+        try:
+            data = json.loads(body_bytes.decode("utf-8"))
+            items = data if isinstance(data, list) else data.get("results", data.get("data", []))
+        except Exception:
+            items = []
+
+        evidence_list: List[SourceEvidence] = []
+        for item in items:
+            if isinstance(item, dict):
+                url = item.get("url", "").strip()
+                excerpt = item.get("snippet", item.get("excerpt", "")).strip()
+            else:
+                continue
+            if url or excerpt:
+                evidence_list.append(
+                    SourceEvidence(url=url, excerpt=excerpt, source_type="desearch")
+                )
+
+        synapse.veridex_response = evidence_list
+        bt.logging.info(
+            f"{synapse.request_id} | Miner returns {len(evidence_list)} Desearch evidence items"
+        )
+        return synapse
+
+    def setup_axon(self):
+        self.axon = bt.axon(wallet=self.wallet, config=self.config)
+        self.axon.attach(forward_fn=self.veridex_forward, blacklist_fn=self.blacklist_fn)
+        self.axon.serve(netuid=self.config.netuid, subtensor=self.subtensor)
+        self.axon.start()
+
+    def run(self):
+        self.setup_axon()
+        self.setup_proxy_logger()
+        step = 0
+        while True:
+            try:
+                if step % 60 == 0:
+                    self.metagraph.sync()
+                step += 1
+                time.sleep(1)
+            except KeyboardInterrupt:
+                self.axon.stop()
+                break
+            except Exception as e:
+                bt.logging.error(traceback.format_exc())
+                continue
+
+
+if __name__ == "__main__":
+    Miner().run()

--- a/miner/desearch/miner.py
+++ b/miner/desearch/miner.py
@@ -12,7 +12,10 @@ import json
 import os
 import time
 import traceback
-from typing import Tuple, List
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Tuple, List, Optional
+from urllib.parse import urlencode
 
 import bittensor as bt
 import requests
@@ -24,6 +27,7 @@ from shared.proxy_log_handler import register_proxy_log_handler
 from shared.veridex_protocol import (
     VericoreSynapse,
     SourceEvidence,
+    SourceType,
     Desearch,
     DesearchProof,
 )
@@ -35,8 +39,32 @@ DESEARCH_COLDKEY_SS58_ENV = os.environ.get("DESEARCH_COLDKEY_SS58", "").strip()
 bt.logging.set_trace()
 load_dotenv()
 
-# Desearch search endpoint (adjust if API differs)
-DESEARCH_SEARCH_PATH = "/search"
+# Desearch SERP (legacy): GET /web?num=5&start=0&query=...
+DESEARCH_SERP_SEARCH_PATH = "/web"
+DESEARCH_SERP_NUM_RESULTS = 5
+DESEARCH_SERP_START = 0
+
+# Max evidence items taken per Desearch source (SERP, web, twitter). Each source contributes at most this many.
+DESEARCH_MAX_EVIDENCE_PER_SOURCE = 5
+
+# Desearch new endpoints (POST, JSON body)
+DESEARCH_WEB_SEARCH_PATH = "/desearch/ai/search/links/web"
+DESEARCH_TWITTER_SEARCH_PATH = "/desearch/ai/search/links/twitter"
+DESEARCH_WEB_TOOLS = ["web", "reddit", "wikipedia"]
+
+# Feature flags (env-configurable)
+DESEARCH_ENABLE_SERP = os.environ.get("DESEARCH_ENABLE_SERP", "false").lower() == "true"
+DESEARCH_ENABLE_WEB = os.environ.get("DESEARCH_ENABLE_WEB", "false").lower() == "true"
+DESEARCH_ENABLE_TWITTER = os.environ.get("DESEARCH_ENABLE_TWITTER", "true").lower() == "true"
+
+
+@dataclass
+class DesearchApiResponse:
+    """Raw response from the Desearch API including proof headers."""
+    body: bytes
+    signature_hex: str
+    timestamp: str
+    expiry: str
 
 
 class Miner:
@@ -80,7 +108,10 @@ class Miner:
         return config
 
     def setup_logging(self):
-        bt.logging(config=self.config, logging_dir=self.config.full_path)
+        if DESEARCH_COLDKEY_SS58_ENV:
+            bt.logging(config=None, logging_dir=self.config.full_path)
+        else:
+            bt.logging(config=self.config, logging_dir=self.config.full_path)
 
     def setup_proxy_logger(self):
         bt_logger = __import__("logging").getLogger("bittensor")
@@ -115,90 +146,251 @@ class Miner:
             return True, None
         try:
             neuron_uid = self.metagraph.hotkeys.index(synapse.dendrite.hotkey)
+
+            bt.logging.info(f"Blacklisting neuron {synapse.dendrite.hotkey} with uid {neuron_uid}")
+
             neuron = self.metagraph.neurons[neuron_uid]
             if not neuron.validator_permit:
                 return True, None
             if neuron.axon_info is None or not neuron.axon_info.is_serving:
                 return True, None
+
+            bt.logging.warning(f"Invalid validator with hotkey {synapse.dendrite.hotkey} with uid {neuron_uid}")                
             return False, None
         except (ValueError, IndexError):
             return True, None
 
-    def call_desearch(self, statement: str) -> tuple[bytes, str, str, str] | None:
-        """
-        Call Desearch API once. Returns (response_body_bytes, signature_hex, timestamp, expiry) or None.
-        """
-        if not DESEARCH_API_KEY or not self.coldkey_ss58:
+    def call_desearch_serp_web_search(self, statement: str) -> Optional[DesearchApiResponse]:
+        """Legacy SERP web search: GET /web. Returns DesearchApiResponse or None."""
+        if not DESEARCH_API_KEY:
+            bt.logging.debug("call_desearch_serp: skipped — DESEARCH_API_KEY not set")
             return None
-        url = f"{DESEARCH_BASE_URL.rstrip('/')}{DESEARCH_SEARCH_PATH}"
+        if not self.coldkey_ss58:
+            bt.logging.debug("call_desearch_serp: skipped — coldkey_ss58 not set")
+            return None
+        params = {
+            "num": DESEARCH_SERP_NUM_RESULTS,
+            "start": DESEARCH_SERP_START,
+            "query": statement,
+        }
+        url = f"{DESEARCH_BASE_URL.rstrip('/')}{DESEARCH_SERP_SEARCH_PATH}?{urlencode(params)}"
         headers = {
-            "Authorization": f"Bearer {DESEARCH_API_KEY}",
-            "X-Coldkey": self.coldkey_ss58,
+            "Accept": "application/json",
             "Content-Type": "application/json",
         }
+        if DESEARCH_API_KEY:
+            headers["Authorization"] = f"{DESEARCH_API_KEY}"
+        if self.coldkey_ss58:
+            headers["X-Coldkey"] = self.coldkey_ss58
+        bt.logging.info(
+            f"call_desearch_serp: GET {url[:80]}... X-Coldkey={self.coldkey_ss58[:12]}..."
+        )
         try:
-            resp = requests.post(
-                url,
-                json={"query": statement},
-                headers=headers,
-                timeout=60,
-            )
+            resp = requests.get(url, headers=headers, timeout=60)
             body_bytes = resp.content
             sig = resp.headers.get("X-Proof-Signature", "")
             ts = resp.headers.get("X-Proof-Timestamp", "")
             exp = resp.headers.get("X-Proof-Expiry", "")
-            return (body_bytes, sig, ts, exp)
+            bt.logging.info(
+                f"call_desearch_serp: status={resp.status_code} body_len={len(body_bytes)} "
+                f"proof={bool(sig)} timestamp={bool(ts)} expiry={bool(exp)}"
+            )
+            if resp.status_code != 200:
+                try:
+                    body_preview = body_bytes[:200].decode("utf-8", errors="replace").strip()
+                except Exception:
+                    body_preview = repr(body_bytes[:100])
+                bt.logging.warning(
+                    f"call_desearch_serp: non-200 status={resp.status_code} body_preview={body_preview!r}"
+                )
+            if not (sig and ts and exp):
+                bt.logging.warning("call_desearch_serp: missing proof headers")
+            return DesearchApiResponse(body=body_bytes, signature_hex=sig, timestamp=ts, expiry=exp)
         except Exception as e:
-            bt.logging.warning(f"Desearch API call failed: {e}")
+            bt.logging.warning(f"call_desearch_serp failed: {e}")
             return None
+
+    def _call_desearch_post(self, endpoint: str, payload: dict) -> Optional[DesearchApiResponse]:
+        """Shared POST helper for the new Desearch endpoints. Returns DesearchApiResponse or None."""
+        if not DESEARCH_API_KEY:
+            bt.logging.debug(f"_call_desearch_post({endpoint}): skipped — DESEARCH_API_KEY not set")
+            return None
+        if not self.coldkey_ss58:
+            bt.logging.debug(f"_call_desearch_post({endpoint}): skipped — coldkey_ss58 not set")
+            return None
+        url = f"{DESEARCH_BASE_URL.rstrip('/')}{endpoint}"
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Authorization": DESEARCH_API_KEY,
+            "X-Coldkey": self.coldkey_ss58,
+        }
+        bt.logging.info(
+            f"_call_desearch_post: POST {url[:80]}... X-Coldkey={self.coldkey_ss58[:12]}..."
+        )
+        try:
+            resp = requests.post(url, headers=headers, json=payload, timeout=60)
+            body_bytes = resp.content
+            sig = resp.headers.get("X-Proof-Signature", "")
+            ts = resp.headers.get("X-Proof-Timestamp", "")
+            exp = resp.headers.get("X-Proof-Expiry", "")
+            bt.logging.info(
+                f"_call_desearch_post({endpoint}): status={resp.status_code} body_len={len(body_bytes)} "
+                f"proof={bool(sig)} timestamp={bool(ts)} expiry={bool(exp)}"
+            )
+            if resp.status_code != 200:
+                try:
+                    body_preview = body_bytes[:200].decode("utf-8", errors="replace").strip()
+                except Exception:
+                    body_preview = repr(body_bytes[:100])
+                bt.logging.warning(
+                    f"_call_desearch_post({endpoint}): non-200 status={resp.status_code} body_preview={body_preview!r}"
+                )
+            if not (sig and ts and exp):
+                bt.logging.warning(f"_call_desearch_post({endpoint}): missing proof headers")
+            return DesearchApiResponse(body=body_bytes, signature_hex=sig, timestamp=ts, expiry=exp)
+        except Exception as e:
+            bt.logging.warning(f"_call_desearch_post({endpoint}) failed: {e}")
+            return None
+
+    def call_desearch_web(self, statement: str) -> Optional[DesearchApiResponse]:
+        """POST /desearch/ai/search/links/web with tools."""
+        return self._call_desearch_post(
+            DESEARCH_WEB_SEARCH_PATH,
+            {"prompt": statement, "tools": DESEARCH_WEB_TOOLS},
+        )
+
+    def call_desearch_twitter(self, statement: str) -> Optional[DesearchApiResponse]:
+        """POST /desearch/ai/search/links/twitter."""
+        return self._call_desearch_post(
+            DESEARCH_TWITTER_SEARCH_PATH,
+            {"prompt": statement},
+        )
+
+    def _parse_serp_results(self, body: bytes) -> List[SourceEvidence]:
+        """Parse legacy SERP GET /web response into SourceEvidence list."""
+        try:
+            data = json.loads(body.decode("utf-8"))
+            items = data if isinstance(data, list) else data.get("results", data.get("data", []))
+        except Exception:
+            return []
+        evidence: List[SourceEvidence] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            url = (item.get("link", item.get("url", "")) or "").strip()
+            excerpt = (item.get("snippet", item.get("excerpt", "")) or "").strip()
+            if url or excerpt:
+                evidence.append(SourceEvidence(url=url, excerpt=excerpt, source_type=SourceType.DESEARCH.value))
+        return evidence
+
+    # The web endpoint returns multiple result groups (search_results, reddit_search_results,
+    # wikipedia_search_results, youtube_search_results, etc.). Only groups listed here are
+    # ingested as evidence; all others are discarded. Twitter is handled by a separate endpoint.
+    DESEARCH_WEB_PRIORITY_KEYS = {"reddit_search_results"}
+
+    def _parse_web_results(self, body: bytes) -> List[SourceEvidence]:
+        """Parse POST /desearch/ai/search/links/web response. Only keeps priority result groups (reddit)."""
+        try:
+            data = json.loads(body.decode("utf-8"))
+        except Exception:
+            return []
+        if not isinstance(data, dict):
+            return []
+        evidence: List[SourceEvidence] = []
+        for key in self.DESEARCH_WEB_PRIORITY_KEYS:
+            items = data.get(key)
+            if not isinstance(items, list):
+                continue
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                url = (item.get("link", item.get("url", "")) or "").strip()
+                excerpt = (item.get("snippet", item.get("excerpt", "")) or "").strip()
+                if url or excerpt:
+                    evidence.append(SourceEvidence(url=url, excerpt=excerpt, source_type=SourceType.DESEARCH.value))
+        return evidence
+
+    def _parse_twitter_results(self, body: bytes) -> List[SourceEvidence]:
+        """Parse POST /desearch/ai/search/links/twitter response. Extracts from miner_tweets."""
+        try:
+            data = json.loads(body.decode("utf-8"))
+        except Exception:
+            return []
+        tweets = data.get("miner_tweets", []) if isinstance(data, dict) else []
+        evidence: List[SourceEvidence] = []
+        for tweet in tweets:
+            if not isinstance(tweet, dict):
+                continue
+            url = (tweet.get("url", "") or "").strip()
+            excerpt = (tweet.get("text", "") or "").strip()
+            if url or excerpt:
+                evidence.append(SourceEvidence(url=url, excerpt=excerpt, source_type=SourceType.DESEARCH.value))
+        return evidence
 
     def veridex_forward(self, synapse: VericoreSynapse) -> VericoreSynapse:
         bt.logging.info(f"{synapse.request_id} | Received Vericore request")
         statement = synapse.statement
         synapse.veridex_response = []
 
-        result = self.call_desearch(statement)
-        if not result:
-            bt.logging.info(f"{synapse.request_id} | No Desearch response, returning empty")
-            return synapse
-
-        body_bytes, signature_hex, timestamp, expiry = result
-        if not (signature_hex and timestamp and expiry):
-            bt.logging.warning(f"{synapse.request_id} | Desearch response missing proof headers")
-            return synapse
-
-        # Set proof on root (body base64 + proof from headers)
-        synapse.desearch = Desearch(
-            response_body=base64.b64encode(body_bytes).decode("ascii"),
-            proof=DesearchProof(
-                signature=signature_hex,
-                timestamp=timestamp,
-                expiry=expiry,
-            ),
-        )
-
-        # Parse response and build evidence (assume JSON list of {url, snippet})
-        try:
-            data = json.loads(body_bytes.decode("utf-8"))
-            items = data if isinstance(data, list) else data.get("results", data.get("data", []))
-        except Exception:
-            items = []
-
+        valid_results: List[DesearchApiResponse] = []
         evidence_list: List[SourceEvidence] = []
-        for item in items:
-            if isinstance(item, dict):
-                url = item.get("url", "").strip()
-                excerpt = item.get("snippet", item.get("excerpt", "")).strip()
-            else:
-                continue
-            if url or excerpt:
-                evidence_list.append(
-                    SourceEvidence(url=url, excerpt=excerpt, source_type="desearch")
+
+        parsers = {
+            "serp": self._parse_serp_results,
+            "web": self._parse_web_results,
+            "twitter": self._parse_twitter_results,
+        }
+
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            futures = {}
+            if DESEARCH_ENABLE_SERP:
+                futures["serp"] = pool.submit(self.call_desearch_serp_web_search, statement)
+            if DESEARCH_ENABLE_WEB:
+                futures["web"] = pool.submit(self.call_desearch_web, statement)
+            if DESEARCH_ENABLE_TWITTER:
+                futures["twitter"] = pool.submit(self.call_desearch_twitter, statement)
+
+            for key, future in futures.items():
+                try:
+                    result = future.result()
+                except Exception as e:
+                    bt.logging.warning(f"{synapse.request_id} | Desearch {key} call raised: {e}")
+                    continue
+                if not result:
+                    bt.logging.info(f"{synapse.request_id} | Desearch {key}: no response")
+                    continue
+                if not (result.signature_hex and result.timestamp and result.expiry):
+                    bt.logging.warning(f"{synapse.request_id} | Desearch {key}: missing proof headers")
+                    continue
+                valid_results.append(result)
+                parsed = parsers[key](result.body)
+                taken = parsed[:DESEARCH_MAX_EVIDENCE_PER_SOURCE]
+                evidence_list.extend(taken)
+                bt.logging.info(
+                    f"{synapse.request_id} | Desearch {key}: {len(taken)} evidence items (of {len(parsed)} parsed), "
+                    f"body_len={len(result.body)} proof_sig_len={len(result.signature_hex)}"
                 )
 
+        if not valid_results:
+            bt.logging.info(f"{synapse.request_id} | No valid Desearch responses, returning empty")
+            return synapse
+
+        synapse.desearch = [
+            Desearch(
+                response_body=base64.b64encode(r.body).decode("ascii"),
+                proof=DesearchProof(
+                    signature=r.signature_hex,
+                    timestamp=r.timestamp,
+                    expiry=r.expiry,
+                ),
+            )
+            for r in valid_results
+        ]
         synapse.veridex_response = evidence_list
         bt.logging.info(
-            f"{synapse.request_id} | Miner returns {len(evidence_list)} Desearch evidence items"
+            f"{synapse.request_id} | Miner returns {len(evidence_list)} evidence items "
+            f"from {len(valid_results)} Desearch endpoint(s)"
         )
         return synapse
 

--- a/shared/blacklisted_domain_cache.py
+++ b/shared/blacklisted_domain_cache.py
@@ -9,20 +9,21 @@ class BlacklistedDomainCache:
     def __init__(self):
         dashboard_api_url = DASHBOARD_API_URL
         self.url = f"{dashboard_api_url}/blacklisted-domains"
-        self.cache = self.fetch_blacklisted_domains()
+        self.cache = self.fetch_blacklisted_domains() or set()
         self.time_refreshed = None
 
 
-    def fetch_blacklisted_domains(self) :
+    def fetch_blacklisted_domains(self):
         try:
             bt.logging.info(f"VALIDATOR | Fetching blacklisted domains from {self.url}")
             response = requests.get(self.url, timeout=300)
             bt.logging.info(f"VALIDATOR | blacklisted_domains_cache fetched")
-            # set time refreshed
+            data = response.json()
             self.time_refreshed = time.time()
-            return {record["domain"] for record in response.json()}
-        except requests.exceptions.RequestException as e:
+            return {record["domain"] for record in data} if isinstance(data, list) else set()
+        except Exception as e:
             bt.logging.error(f"VALIDATOR | Failed to fetch blacklisted domains: {e}")
+            return set()
 
     def get_cache(self):
         return self.cache
@@ -39,15 +40,12 @@ def get_blacklisted_domain_cache_data():
     if blacklisted_domain_cache.requires_refresh():
         bt.logging.info("Refreshing blacklisted domains cache")
         blacklisted_domain_cache.cache = blacklisted_domain_cache.fetch_blacklisted_domains()
-
-
-    return blacklisted_domain_cache.cache
+    return blacklisted_domain_cache.cache if blacklisted_domain_cache.cache is not None else set()
 
 
 def is_blacklisted_domain(request_id: str, miner_uid: int, domain: str):
     bt.logging.info(f"{request_id} | {miner_uid} | Validating domain {domain}")
     cache_data = get_blacklisted_domain_cache_data()
-
     blacklisted_domain = domain in cache_data
 
     bt.logging.info(f"{request_id} | {miner_uid} | {domain} is blacklisted : {blacklisted_domain} ")

--- a/shared/desearch_proof.py
+++ b/shared/desearch_proof.py
@@ -1,8 +1,29 @@
 """
-Verify Desearch proof: signature over (coldkey|data_hash|timestamp|expiry) using miner's coldkey.
+Verify Desearch proof: signature over (coldkey|data_hash|timestamp|expiry).
+
+  - data_hash = SHA256(response_body).hexdigest()
+  - message = f"{coldkey}|{data_hash}|{timestamp}|{expiry}"  (coldkey = miner's SS58, for binding)
+  - Signature is verified with Desearch's public key (DESEARCH_PUBLIC_KEY).
 """
 import hashlib
+import logging
 from datetime import datetime, timezone
+
+# Desearch's SS58 public key; used to verify X-Proof-Signature.
+DESEARCH_PUBLIC_KEY = "5CdQ3YfmGPJojVahShC2EyT9rUmThecZQiiLquDKVNYCGhbX"
+
+logger = logging.getLogger(__name__)
+
+
+def _log(level: str, msg: str, *args) -> None:
+    """Log to standard logger and bt.logging when available (e.g. validator)."""
+    formatted = msg % args if args else msg
+    getattr(logger, level)(msg, *args)
+    try:
+        import bittensor as bt
+        getattr(bt.logging, level)(formatted)
+    except (ImportError, AttributeError):
+        pass
 
 
 def verify_proof(
@@ -13,10 +34,10 @@ def verify_proof(
     expiry: str,
 ) -> bool:
     """
-    Verify Desearch proof: check expiry, reconstruct message, verify signature with miner's coldkey.
+    Verify Desearch proof: check expiry, reconstruct message, verify signature with Desearch's public key.
 
     Args:
-        coldkey: Miner's coldkey SS58 (from metagraph).
+        coldkey: Miner's coldkey SS58 (included in the signed message for binding; from metagraph).
         response_body: Raw Desearch response body bytes.
         signature_hex: X-Proof-Signature (hex).
         timestamp: X-Proof-Timestamp.
@@ -25,14 +46,27 @@ def verify_proof(
     Returns:
         True if proof is valid and not expired, False otherwise.
     """
+    coldkey_preview = coldkey[:16] + "..." if len(coldkey) > 16 else coldkey
+    _log(
+        "info",
+        "desearch_proof verify_proof received: coldkey=%s response_body_len=%s signature_hex_len=%s timestamp=%s expiry=%s",
+        coldkey_preview,
+        len(response_body),
+        len(signature_hex),
+        timestamp,
+        expiry,
+    )
+
     # 1. Check expiry
     try:
         expiry_dt = datetime.fromisoformat(expiry.replace("Z", "+00:00"))
         if expiry_dt.tzinfo is None:
             expiry_dt = expiry_dt.replace(tzinfo=timezone.utc)
         if datetime.now(timezone.utc) > expiry_dt:
+            _log("warning", "desearch_proof: expired (expiry=%s)", expiry)
             return False
-    except (ValueError, TypeError):
+    except (ValueError, TypeError) as e:
+        _log("warning", "desearch_proof: malformed expiry=%s error=%s", expiry, e)
         return False
 
     # 2. Hash the response body
@@ -41,11 +75,13 @@ def verify_proof(
     # 3. Reconstruct the signed message
     message = f"{coldkey}|{data_hash}|{timestamp}|{expiry}"
     message_bytes = message.encode("utf-8")
+    _log("info", "desearch_proof: data_hash=%s message=%s", data_hash, message)
 
-    # 4. Verify signature with miner's coldkey (public key)
+    # 4. Verify signature against Desearch's public key
     try:
         sig_bytes = bytes.fromhex(signature_hex)
-    except (ValueError, TypeError):
+    except (ValueError, TypeError) as e:
+        _log("warning", "desearch_proof: invalid signature_hex (len=%s) error=%s", len(signature_hex), e)
         return False
 
     try:
@@ -58,5 +94,7 @@ def verify_proof(
                 "Desearch proof verification requires bittensor or bittensor_wallet (Keypair.verify)"
             ) from None
 
-    keypair = Keypair(ss58_address=coldkey)
-    return keypair.verify(message_bytes, sig_bytes)
+    keypair = Keypair(ss58_address=DESEARCH_PUBLIC_KEY)
+    ok = keypair.verify(message_bytes, sig_bytes)
+    _log("info", "desearch_proof: keypair.verify result=%s", ok)
+    return ok

--- a/shared/desearch_proof.py
+++ b/shared/desearch_proof.py
@@ -1,0 +1,62 @@
+"""
+Verify Desearch proof: signature over (coldkey|data_hash|timestamp|expiry) using miner's coldkey.
+"""
+import hashlib
+from datetime import datetime, timezone
+
+
+def verify_proof(
+    coldkey: str,
+    response_body: bytes,
+    signature_hex: str,
+    timestamp: str,
+    expiry: str,
+) -> bool:
+    """
+    Verify Desearch proof: check expiry, reconstruct message, verify signature with miner's coldkey.
+
+    Args:
+        coldkey: Miner's coldkey SS58 (from metagraph).
+        response_body: Raw Desearch response body bytes.
+        signature_hex: X-Proof-Signature (hex).
+        timestamp: X-Proof-Timestamp.
+        expiry: X-Proof-Expiry.
+
+    Returns:
+        True if proof is valid and not expired, False otherwise.
+    """
+    # 1. Check expiry
+    try:
+        expiry_dt = datetime.fromisoformat(expiry.replace("Z", "+00:00"))
+        if expiry_dt.tzinfo is None:
+            expiry_dt = expiry_dt.replace(tzinfo=timezone.utc)
+        if datetime.now(timezone.utc) > expiry_dt:
+            return False
+    except (ValueError, TypeError):
+        return False
+
+    # 2. Hash the response body
+    data_hash = hashlib.sha256(response_body).hexdigest()
+
+    # 3. Reconstruct the signed message
+    message = f"{coldkey}|{data_hash}|{timestamp}|{expiry}"
+    message_bytes = message.encode("utf-8")
+
+    # 4. Verify signature with miner's coldkey (public key)
+    try:
+        sig_bytes = bytes.fromhex(signature_hex)
+    except (ValueError, TypeError):
+        return False
+
+    try:
+        from bittensor import Keypair
+    except ImportError:
+        try:
+            from bittensor_wallet import Keypair  # type: ignore
+        except ImportError:
+            raise ImportError(
+                "Desearch proof verification requires bittensor or bittensor_wallet (Keypair.verify)"
+            ) from None
+
+    keypair = Keypair(ss58_address=coldkey)
+    return keypair.verify(message_bytes, sig_bytes)

--- a/shared/environment_variables.py
+++ b/shared/environment_variables.py
@@ -37,6 +37,7 @@ VALIDATOR_JWT_ALGORITHM = os.environ.get("VALIDATOR_JWT_ALGORITHM", "RS512")
 INITIAL_WEIGHT = 0.7
 
 # Desearch (miner-side): API key for Desearch; set when using Desearch miner.
+# Web search: GET https://api.desearch.ai/web?num=10&start=0&query=...
 DESEARCH_API_KEY = os.environ.get("DESEARCH_API_KEY", "")
 DESEARCH_BASE_URL = os.environ.get("DESEARCH_BASE_URL", "https://api.desearch.ai")
 

--- a/shared/environment_variables.py
+++ b/shared/environment_variables.py
@@ -36,6 +36,10 @@ VALIDATOR_JWT_ALGORITHM = os.environ.get("VALIDATOR_JWT_ALGORITHM", "RS512")
 
 INITIAL_WEIGHT = 0.7
 
+# Desearch (miner-side): API key for Desearch; set when using Desearch miner.
+DESEARCH_API_KEY = os.environ.get("DESEARCH_API_KEY", "")
+DESEARCH_BASE_URL = os.environ.get("DESEARCH_BASE_URL", "https://api.desearch.ai")
+
 NEUTRAL_SCORE=10
 IMMUNITY_PERIOD = 100 # Ensures new miners have a full day to prove themselves, even if other miners have been idle.
 IMMUNITY_WEIGHT = 0.5

--- a/shared/scores.py
+++ b/shared/scores.py
@@ -21,3 +21,8 @@ DOMAIN_REGISTERED_RECENTLY = -1
 
 # Gaming responses
 SNIPPET_SAME_AS_STATEMENT = -10
+
+# Desearch
+DESEARCH_SNIPPET_BONUS = 1  # Extra point per verified Desearch snippet
+DESEARCH_PROOF_INVALID = 0  # Score/reason when proof verification fails
+DESEARCH_PROOF_EXPIRED = 0  # Score/reason when proof is expired

--- a/shared/scores.py
+++ b/shared/scores.py
@@ -22,7 +22,14 @@ DOMAIN_REGISTERED_RECENTLY = -1
 # Gaming responses
 SNIPPET_SAME_AS_STATEMENT = -10
 
-# Desearch
-DESEARCH_SNIPPET_BONUS = 1  # Extra point per verified Desearch snippet
-DESEARCH_PROOF_INVALID = 0  # Score/reason when proof verification fails
-DESEARCH_PROOF_EXPIRED = 0  # Score/reason when proof is expired
+# Desearch (miner-level, applied once per miner response)
+DESEARCH_PROOF_VALID_BONUS = 2
+DESEARCH_PROOF_INVALID_PENALTY = -5
+# Desearch snippet: evidence URL/excerpt not found in response body
+DESEARCH_EVIDENCE_NOT_IN_RESPONSE = -1
+
+# Social bonus (per desearch snippet only): x.com → +1, reddit.com → +0.5
+SOCIAL_BONUS_DOMAIN_X = 1.0
+SOCIAL_BONUS_DOMAIN_REDDIT = 0.5
+SOCIAL_BONUS_DOMAINS_X = ("x.com", "twitter.com")  # domains that receive SOCIAL_BONUS_DOMAIN_X
+SOCIAL_BONUS_DOMAIN_REDDIT_NAME = "reddit.com"

--- a/shared/top_site_cache.py
+++ b/shared/top_site_cache.py
@@ -6,16 +6,18 @@ class TopSitesCache:
     def __init__(self):
         dashboard_api_url = DASHBOARD_API_URL
         self.url = f"{dashboard_api_url}/acceptable-top-level-domains"
-        self.cache = self.fetch_top_sites()
+        self.cache = self.fetch_top_sites() or set()
 
-    def fetch_top_sites(self) :
+    def fetch_top_sites(self):
         try:
             bt.logging.info(f"VALIDATOR | Fetching domains from {self.url}")
             response = requests.get(self.url, timeout=300)
             bt.logging.info(f"VALIDATOR | Top domain cache fetched")
-            return {record["tld"] for record in response.json()}
-        except requests.exceptions.RequestException as e:
+            data = response.json()
+            return {record["tld"] for record in data} if isinstance(data, list) else set()
+        except Exception as e:
             bt.logging.error(f"VALIDATOR | Failed to fetch domains: {e}")
+            return set()
 
     def get_cache(self):
         return self.cache
@@ -26,14 +28,12 @@ top_sites_cache = TopSitesCache()
 def get_top_site_cache_data():
     if top_sites_cache.cache is None:
         top_sites_cache.cache = top_sites_cache.fetch_top_sites()
-
-    return top_sites_cache.cache
+    return top_sites_cache.cache if top_sites_cache.cache is not None else set()
 
 
 def is_approved_site(request_id: str, miner_uid: int, site: str):
     bt.logging.info(f"{request_id} | {miner_uid} | Validating site {site}")
     cache_data = get_top_site_cache_data()
-
     valid_site = site in cache_data
 
     bt.logging.info(f"{request_id} | {miner_uid} | {site} is acceptable : {valid_site} ")

--- a/shared/veridex_protocol.py
+++ b/shared/veridex_protocol.py
@@ -66,9 +66,27 @@ class QueryResponseTiming:
 class SourceEvidence(typing.NamedTuple):
     """
     Container for a single piece of evidence from a miner.
+    source_type: "web" or "desearch" (default "web" for backward compatibility).
     """
     url: str
     excerpt: str = ""  # The snippet text the miner claims is from the URL
+    source_type: str = "web"  # "web" | "desearch"
+
+
+@dataclass
+class DesearchProof:
+    """Proof headers from Desearch API response (X-Proof-Signature, X-Proof-Timestamp, X-Proof-Expiry)."""
+    signature: str = ""  # hex
+    timestamp: str = ""
+    expiry: str = ""
+
+
+@dataclass
+class Desearch:
+    """Full Desearch response on the synapse: body (base64) and proof from response headers."""
+    response_body: str = ""  # base64-encoded full Desearch response body
+    proof: DesearchProof = field(default_factory=DesearchProof)
+
 
 class VericoreSynapse(bt.Synapse):
     """
@@ -84,6 +102,7 @@ class VericoreSynapse(bt.Synapse):
     statement: str
     sources: typing.List[str] = []
     veridex_response: typing.Optional[typing.List[SourceEvidence]] = None
+    desearch: typing.Optional[Desearch] = None  # When miner used Desearch: body + proof from response headers
 
 @dataclass
 class VeridexResponse:
@@ -127,6 +146,7 @@ class VericoreStatementResponse():
   risk_reward_sentiment: float = 0.0
   catalyst_detection: float = 0.0
   political_leaning: float = 0.0
+  desearch_bonus: float = 0.0  # DESEARCH_SNIPPET_BONUS when snippet received Desearch bonus, else 0
 
 @dataclass
 class VericoreMinerStatementResponse():
@@ -146,6 +166,7 @@ class VericoreMinerStatementResponse():
   max_snippet_time_secs: float = 0
   snippet_count: int = 0
   timing: typing.Optional["MinerResponseTiming"] = None  # Nested timing DTO
+  desearch_bonus: float = 0.0  # Sum of desearch_bonus across vericore_responses
 
 @dataclass
 class VericoreQueryResponse():

--- a/shared/veridex_protocol.py
+++ b/shared/veridex_protocol.py
@@ -1,6 +1,7 @@
 # veridex_protocol.py
 import typing
 from dataclasses import dataclass, field
+from enum import Enum
 
 import bittensor as bt
 
@@ -63,14 +64,20 @@ class QueryResponseTiming:
     miner_count: int = 0
 
 
+class SourceType(str, Enum):
+    """Source type for evidence. Wire format is the string value."""
+    WEB = "web"
+    DESEARCH = "desearch"
+
+
 class SourceEvidence(typing.NamedTuple):
     """
     Container for a single piece of evidence from a miner.
-    source_type: "web" or "desearch" (default "web" for backward compatibility).
+    source_type: SourceType.WEB or SourceType.DESEARCH (wire format: "web" | "desearch").
     """
     url: str
     excerpt: str = ""  # The snippet text the miner claims is from the URL
-    source_type: str = "web"  # "web" | "desearch"
+    source_type: str = "web"  # SourceType.WEB.value | SourceType.DESEARCH.value
 
 
 @dataclass
@@ -102,7 +109,7 @@ class VericoreSynapse(bt.Synapse):
     statement: str
     sources: typing.List[str] = []
     veridex_response: typing.Optional[typing.List[SourceEvidence]] = None
-    desearch: typing.Optional[Desearch] = None  # When miner used Desearch: body + proof from response headers
+    desearch: typing.Optional[typing.List[Desearch]] = None
 
 @dataclass
 class VeridexResponse:
@@ -146,7 +153,7 @@ class VericoreStatementResponse():
   risk_reward_sentiment: float = 0.0
   catalyst_detection: float = 0.0
   political_leaning: float = 0.0
-  desearch_bonus: float = 0.0  # DESEARCH_SNIPPET_BONUS when snippet received Desearch bonus, else 0
+  social_bonus_contribution: float = 0.0  # This excerpt's contribution to miner social_bonus_score (0, 0.5, or 1.0)
 
 @dataclass
 class VericoreMinerStatementResponse():
@@ -166,7 +173,8 @@ class VericoreMinerStatementResponse():
   max_snippet_time_secs: float = 0
   snippet_count: int = 0
   timing: typing.Optional["MinerResponseTiming"] = None  # Nested timing DTO
-  desearch_bonus: float = 0.0  # Sum of desearch_bonus across vericore_responses
+  desearch_bonus_score: float = 0.0  # Miner-level desearch proof bonus/penalty
+  social_bonus_score: float = 0.0  # Sum of per-snippet social bonus (desearch only: x.com +1, reddit.com +0.5)
 
 @dataclass
 class VericoreQueryResponse():

--- a/shared/wallet_api_key_utils.py
+++ b/shared/wallet_api_key_utils.py
@@ -1,0 +1,99 @@
+"""
+Utilities to link a wallet address (Bittensor SS58) to an API key (JWT).
+
+Linking is done by including a wallet claim in the JWT. Issuers create tokens with
+that claim; the validator reads it after verifying the token and can use it for
+authorization or attribution.
+
+Usage:
+- Issuer: build payload with build_wallet_link_payload(), sign with your private key,
+  and give the JWT to the client as the API key.
+- Validator: after decoding the JWT, call get_linked_wallet_from_payload(payload)
+  to get the wallet address, if present.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# JWT claim name for the linked wallet (SS58 address).
+WALLET_CLAIM = "wallet"
+
+# Optional: SS58 format is base58 with 48-49 chars typically; we only do a loose check.
+_SS58_PATTERN = re.compile(r"^[1-9A-HJ-NP-Za-km-z]{47,49}$")
+
+
+def get_linked_wallet_from_payload(payload: dict[str, Any]) -> str | None:
+    """
+    Return the wallet address linked to this API key (JWT payload), if present.
+
+    Args:
+        payload: Decoded JWT payload (e.g. from jwt.decode).
+
+    Returns:
+        The SS58 wallet address string, or None if no wallet claim or invalid value.
+    """
+    if not payload or not isinstance(payload, dict):
+        return None
+    raw = payload.get(WALLET_CLAIM)
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        return None
+    addr = raw.strip()
+    return addr if addr else None
+
+
+def build_wallet_link_payload(
+    sub: str,
+    wallet_address: str,
+    *,
+    exp_seconds: int | None = None,
+    **extra_claims: Any,
+) -> dict[str, Any]:
+    """
+    Build a JWT payload that links the given wallet to the token (for use as API key).
+
+    Caller should then sign this payload with the validator's JWT private key
+    (e.g. jwt.encode(payload, private_key, algorithm="RS512")).
+
+    Args:
+        sub: JWT subject (e.g. "validator_proxy").
+        wallet_address: SS58 wallet address to link. Will be normalized (stripped).
+        exp_seconds: Optional seconds from now for exp claim; omit for no exp.
+        **extra_claims: Additional claims to include (e.g. iat, jti).
+
+    Returns:
+        Payload dict suitable for jwt.encode.
+    """
+    import time
+
+    payload: dict[str, Any] = {
+        "sub": sub,
+        WALLET_CLAIM: normalize_wallet_address(wallet_address),
+        **extra_claims,
+    }
+    if exp_seconds is not None:
+        payload["exp"] = int(time.time()) + exp_seconds
+    return payload
+
+
+def normalize_wallet_address(addr: str) -> str:
+    """
+    Normalize a wallet address for storage in JWT: strip whitespace and remove
+    any non-breaking space (\\xa0) that can slip in from config/env.
+    """
+    if not addr or not isinstance(addr, str):
+        return ""
+    return addr.replace("\xa0", "").strip()
+
+
+def is_valid_ss58_format(addr: str) -> bool:
+    """
+    Return True if the string looks like an SS58 address (length and charset).
+    Does not verify checksum.
+    """
+    if not addr or not isinstance(addr, str):
+        return False
+    return bool(_SS58_PATTERN.match(addr.strip()))

--- a/tests/unit_tests/snippet_validator_validate_miner_snippet_test.py
+++ b/tests/unit_tests/snippet_validator_validate_miner_snippet_test.py
@@ -1,0 +1,191 @@
+"""
+Unit tests for validate_miner_snippet refactor: dispatch (web vs desearch) and
+response shape parity for normal (web) searches.
+
+Requires bittensor (and project deps); use pytest.importorskip so collection
+is skipped when not installed.
+"""
+import pytest
+
+pytest.importorskip("bittensor")
+
+from unittest.mock import AsyncMock, patch
+
+from shared.veridex_protocol import (
+    SourceEvidence,
+    SourceType,
+    VericoreStatementResponse,
+)
+from validator.snippet_validator import SnippetValidator
+
+
+@pytest.fixture
+def validator():
+    return SnippetValidator()
+
+
+@pytest.fixture
+def web_evidence():
+    """Normal web source evidence (HTTPS)."""
+    return SourceEvidence(
+        url="https://example.com/page",
+        excerpt="Some excerpt from the page.",
+        source_type=SourceType.WEB.value,
+    )
+
+
+@pytest.fixture
+def desearch_evidence():
+    """Desearch source evidence."""
+    return SourceEvidence(
+        url="https://example.com/page",
+        excerpt="Desearch excerpt.",
+        source_type=SourceType.DESEARCH.value,
+    )
+
+
+# --- Dispatch: web vs desearch ---
+
+
+@pytest.mark.asyncio
+async def test_validate_miner_snippet_web_calls_validate_web_snippet(
+    validator, web_evidence
+):
+    """With source_type=web, only _validate_web_snippet is called (no desearch)."""
+    with patch.object(
+        validator, "_validate_web_snippet", new_callable=AsyncMock
+    ) as mock_web:
+        with patch.object(
+            validator, "_validate_desearch_snippet", new_callable=AsyncMock
+        ) as mock_desearch:
+            mock_web.return_value = VericoreStatementResponse(
+                url=web_evidence.url,
+                excerpt=web_evidence.excerpt,
+                domain="example.com",
+                snippet_found=True,
+                local_score=1.0,
+                snippet_score=1.0,
+                snippet_score_reason="",
+            )
+            result = await validator.validate_miner_snippet(
+                request_id="req-1",
+                miner_uid=0,
+                original_statement="Some statement.",
+                miner_evidence=web_evidence,
+                desearch_response_bodies=None,
+            )
+            mock_web.assert_called_once()
+            mock_desearch.assert_not_called()
+            assert result.snippet_found is True
+            assert result.domain == "example.com"
+
+
+@pytest.mark.asyncio
+async def test_validate_miner_snippet_desearch_calls_validate_desearch_snippet(
+    validator, desearch_evidence
+):
+    """With source_type=desearch, only _validate_desearch_snippet is called."""
+    with patch.object(
+        validator, "_validate_web_snippet", new_callable=AsyncMock
+    ) as mock_web:
+        with patch.object(
+            validator, "_validate_desearch_snippet", new_callable=AsyncMock
+        ) as mock_desearch:
+            mock_desearch.return_value = VericoreStatementResponse(
+                url=desearch_evidence.url,
+                excerpt=desearch_evidence.excerpt,
+                domain="example.com",
+                snippet_found=True,
+                local_score=1.0,
+                snippet_score=1.0,
+                snippet_score_reason="",
+            )
+            result = await validator.validate_miner_snippet(
+                request_id="req-1",
+                miner_uid=0,
+                original_statement="Some statement.",
+                miner_evidence=desearch_evidence,
+                desearch_response_bodies=[b"fake body"],
+            )
+            mock_desearch.assert_called_once()
+            mock_web.assert_not_called()
+            assert result.snippet_found is True
+
+
+# --- Web path: response shape parity (early exits, no fetch/assess) ---
+
+
+@pytest.mark.asyncio
+async def test_web_no_snippet_provided_returns_same_shape(validator, web_evidence):
+    """Web path with empty excerpt returns VericoreStatementResponse with no_snippet_provided."""
+    evidence_empty = SourceEvidence(
+        url=web_evidence.url,
+        excerpt="   ",
+        source_type=SourceType.WEB.value,
+    )
+    with patch.object(
+        validator, "validate_miner_url", new_callable=AsyncMock, return_value=None
+    ):
+        result = await validator.validate_miner_snippet(
+            request_id="req-1",
+            miner_uid=0,
+            original_statement="Some statement.",
+            miner_evidence=evidence_empty,
+        )
+    assert isinstance(result, VericoreStatementResponse)
+    assert result.snippet_score_reason == "no_snippet_provided"
+    assert result.snippet_found is False
+    assert result.domain == "example.com"
+    assert result.url == evidence_empty.url
+    assert result.excerpt == evidence_empty.excerpt
+    assert result.timing is not None
+    assert result.verify_miner_time_taken_secs >= 0
+
+
+@pytest.mark.asyncio
+async def test_web_snippet_same_as_statement_returns_same_shape(validator):
+    """Web path when excerpt equals statement returns snippet_same_as_statement."""
+    statement = "The cat sat on the mat."
+    evidence_same = SourceEvidence(
+        url="https://example.com/page",
+        excerpt=statement,
+        source_type=SourceType.WEB.value,
+    )
+    with patch.object(
+        validator, "validate_miner_url", new_callable=AsyncMock, return_value=None
+    ):
+        result = await validator.validate_miner_snippet(
+            request_id="req-1",
+            miner_uid=0,
+            original_statement=statement,
+            miner_evidence=evidence_same,
+        )
+    assert isinstance(result, VericoreStatementResponse)
+    assert result.snippet_score_reason == "snippet_same_as_statement"
+    assert result.snippet_found is False
+    assert result.domain == "example.com"
+    assert result.verify_miner_time_taken_secs >= 0
+
+
+@pytest.mark.asyncio
+async def test_web_exception_returns_error_verifying_miner_snippet(validator):
+    """On exception, validate_miner_snippet returns single error response."""
+    evidence = SourceEvidence(
+        url="https://example.com/page",
+        excerpt="Excerpt.",
+        source_type=SourceType.WEB.value,
+    )
+    with patch.object(
+        validator, "_validate_web_snippet", new_callable=AsyncMock, side_effect=RuntimeError("fail")
+    ):
+        result = await validator.validate_miner_snippet(
+            request_id="req-1",
+            miner_uid=0,
+            original_statement="Statement.",
+            miner_evidence=evidence,
+        )
+    assert isinstance(result, VericoreStatementResponse)
+    assert result.snippet_score_reason == "error_verifying_miner_snippet"
+    assert result.snippet_found is False
+    assert result.domain == ""
+    assert result.verify_miner_time_taken_secs >= 0

--- a/tests/unit_tests/test_desearch_proof.py
+++ b/tests/unit_tests/test_desearch_proof.py
@@ -1,0 +1,82 @@
+"""Unit tests for Desearch proof verification (shared.desearch_proof)."""
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch
+
+from shared.desearch_proof import verify_proof
+
+
+def test_verify_proof_expired_returns_false():
+    """Expired proof should return False before any Keypair use."""
+    expiry_past = (datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat()
+    result = verify_proof(
+        coldkey="5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutgY",
+        response_body=b"{}",
+        signature_hex="00" * 64,
+        timestamp=expiry_past,
+        expiry=expiry_past,
+    )
+    assert result is False
+
+
+def test_verify_proof_invalid_signature_hex_returns_false():
+    """Invalid hex signature should return False."""
+    future = (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat()
+    result = verify_proof(
+        coldkey="5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutgY",
+        response_body=b"{}",
+        signature_hex="not-hex",
+        timestamp=future,
+        expiry=future,
+    )
+    assert result is False
+
+
+def test_verify_proof_malformed_expiry_returns_false():
+    """Malformed expiry should return False."""
+    result = verify_proof(
+        coldkey="5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutgY",
+        response_body=b"{}",
+        signature_hex="00" * 64,
+        timestamp="2024-01-01T00:00:00+00:00",
+        expiry="not-a-date",
+    )
+    assert result is False
+
+
+def test_verify_proof_valid_calls_keypair_verify():
+    """Valid proof should call Keypair.verify and return True (when bittensor available)."""
+    pytest = __import__("pytest")
+    pytest.importorskip("bittensor")
+    with patch("bittensor.Keypair") as mock_keypair_cls:
+        mock_keypair_cls.return_value.verify.return_value = True
+        future = (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat()
+        result = verify_proof(
+            coldkey="5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutgY",
+            response_body=b'{"results":[]}',
+            signature_hex="00" * 64,
+            timestamp=future,
+            expiry=future,
+        )
+        assert result is True
+        mock_keypair_cls.return_value.verify.assert_called_once()
+        msg = mock_keypair_cls.return_value.verify.call_args[0][0]
+        sig = mock_keypair_cls.return_value.verify.call_args[0][1]
+        assert b"|" in msg
+        assert len(sig) == 64
+
+
+def test_verify_proof_verify_returns_false():
+    """When Keypair.verify returns False, verify_proof returns False (when bittensor available)."""
+    pytest = __import__("pytest")
+    pytest.importorskip("bittensor")
+    with patch("bittensor.Keypair") as mock_keypair_cls:
+        mock_keypair_cls.return_value.verify.return_value = False
+        future = (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat()
+        result = verify_proof(
+            coldkey="5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutgY",
+            response_body=b"{}",
+            signature_hex="00" * 64,
+            timestamp=future,
+            expiry=future,
+        )
+        assert result is False

--- a/utils/generate_wallet_linked_token.py
+++ b/utils/generate_wallet_linked_token.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Generate a JWT that links a wallet address to an API key for the validator.
+
+The token can be used as the Bearer API key; the validator will accept it
+(if signed with the matching public key) and can read the linked wallet
+from the payload.
+
+Usage:
+  python -m utils.generate_wallet_linked_token --wallet 5F3sa2TJAWMqDhXG6jhV4N8ko9SxwGy8TpaNS1repo5EYjLQ
+  python -m utils.generate_wallet_linked_token --wallet 5F3sa... --exp-days 30
+
+Requires the validator JWT *private* key. Set one of:
+  VALIDATOR_JWT_PRIVATE_KEY       - PEM string (inline)
+  VALIDATOR_JWT_PRIVATE_KEY_FILE  - Path to PEM file (e.g. keys/validator_jwt_private.pem)
+
+Uses VALIDATOR_JWT_ALGORITHM (default RS512). Run from repo root.
+"""
+import argparse
+import os
+import sys
+
+import jwt
+
+from shared.wallet_api_key_utils import (
+    WALLET_CLAIM,
+    build_wallet_link_payload,
+    is_valid_ss58_format,
+    normalize_wallet_address,
+)
+
+VALIDATOR_PROXY_SUB = "validator_proxy"
+_DEFAULT_ALGORITHM = "RS512"
+
+
+def _load_private_key() -> str | None:
+    inline = os.environ.get("VALIDATOR_JWT_PRIVATE_KEY")
+    if inline:
+        return inline.strip()
+    path = os.environ.get("VALIDATOR_JWT_PRIVATE_KEY_FILE")
+    if path:
+        path = os.path.abspath(os.path.expanduser(path))
+        if os.path.isfile(path):
+            with open(path, "r", encoding="utf-8") as f:
+                return f.read()
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate a wallet-linked JWT for validator API auth."
+    )
+    parser.add_argument(
+        "--wallet",
+        required=True,
+        help="SS58 wallet address to link to this API key.",
+    )
+    parser.add_argument(
+        "--exp-days",
+        type=float,
+        default=30,
+        help="Token expiry in days (default: 30). Use 0 for no expiry.",
+    )
+    parser.add_argument(
+        "--sub",
+        default=VALIDATOR_PROXY_SUB,
+        help=f"JWT subject (default: {VALIDATOR_PROXY_SUB}).",
+    )
+    args = parser.parse_args()
+
+    wallet = normalize_wallet_address(args.wallet)
+    if not wallet:
+        print("Error: --wallet is required and must be non-empty.", file=sys.stderr)
+        return 1
+    if not is_valid_ss58_format(wallet):
+        print(
+            "Warning: wallet does not look like a standard SS58 address (47–49 base58 chars).",
+            file=sys.stderr,
+        )
+
+    private_key = _load_private_key()
+    if not private_key:
+        print(
+            "Error: Set VALIDATOR_JWT_PRIVATE_KEY or VALIDATOR_JWT_PRIVATE_KEY_FILE.",
+            file=sys.stderr,
+        )
+        return 1
+
+    algorithm = os.environ.get("VALIDATOR_JWT_ALGORITHM", _DEFAULT_ALGORITHM)
+    exp_seconds = int(args.exp_days * 86400) if args.exp_days else None
+
+    payload = build_wallet_link_payload(
+        sub=args.sub,
+        wallet_address=wallet,
+        exp_seconds=exp_seconds,
+    )
+    token = jwt.encode(payload, private_key, algorithm=algorithm)
+    if hasattr(token, "decode"):
+        token = token.decode("utf-8")
+
+    print("Wallet-linked JWT (use as Bearer token):")
+    print(token)
+    print(f"\nDecoded claim: {WALLET_CLAIM}={payload.get(WALLET_CLAIM)!r}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/link_desearch_miner.py
+++ b/utils/link_desearch_miner.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+One-time link: bind your Bittensor coldkey to your Desearch account.
+
+Signs your Desearch API key with your coldkey and POSTs to Desearch's
+/bt/miner/link so the miner can use the API with proof.
+
+Usage:
+  python -m utils.link_desearch_miner --wallet.name my_wallet --wallet.hotkey miner_desearch_hotkey
+
+  Password: prompted interactively if not in WALLET_PASSWORD/DESEARCH_WALLET_PASSWORD or --wallet.password.
+
+Requires:
+  - DESEARCH_API_KEY in env (or .env)
+  - Coldkey password (env, --wallet.password, or interactive prompt)
+  - bittensor_wallet: pip install bittensor-wallet
+  - Wallet with a coldkey (same wallet/hotkey as miner; only coldkey is used for the link)
+"""
+import argparse
+import getpass
+import os
+import sys
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DESEARCH_LINK_PATH = "/bt/miner/link"
+
+
+def main() -> int:
+    api_key = os.environ.get("DESEARCH_API_KEY", "").strip()
+    if not api_key:
+        print(
+            "Error: DESEARCH_API_KEY not set. Set it in env or .env.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        from bittensor_wallet import Wallet
+    except ImportError:
+        print(
+            "Error: bittensor_wallet not found. Install with: pip install bittensor-wallet",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        import requests
+    except ImportError:
+        print("Error: requests not found. Install with: pip install requests", file=sys.stderr)
+        return 1
+
+    parser = argparse.ArgumentParser(
+        description="Link your Bittensor coldkey to your Desearch account (one-time)."
+    )
+    parser.add_argument(
+        "--wallet.name",
+        dest="wallet_name",
+        required=True,
+        help="Wallet name (must match the miner; coldkey lives under this name).",
+    )
+    parser.add_argument(
+        "--wallet.path",
+        dest="wallet_path",
+        default=os.environ.get("WALLET_PATH", ""),
+        help="Wallet root directory (default: ~/.bittensor/wallets). Set if miner uses a custom path.",
+    )
+    parser.add_argument(
+        "--wallet.hotkey",
+        dest="wallet_hotkey",
+        default="default",
+        help="Hotkey name (default: default). Same wallet as miner; only coldkey is used for link.",
+    )
+    parser.add_argument(
+        "--wallet.password",
+        dest="wallet_password",
+        default=os.environ.get("DESEARCH_WALLET_PASSWORD", os.environ.get("WALLET_PASSWORD", "")),
+        help="Coldkey password. Default: DESEARCH_WALLET_PASSWORD or WALLET_PASSWORD env.",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=os.environ.get("DESEARCH_BASE_URL", "https://api.desearch.ai"),
+        help="Desearch API base URL (default: DESEARCH_BASE_URL or https://api.desearch.ai)",
+    )
+    args = parser.parse_args()
+
+    password = (args.wallet_password or "").strip()
+    if not password:
+        try:
+            password = getpass.getpass("Coldkey password: ")
+        except (EOFError, KeyboardInterrupt):
+            print("", file=sys.stderr)
+            return 1
+        if not password.strip():
+            print("Error: Coldkey password required.", file=sys.stderr)
+            return 1
+        password = password.strip()
+
+    wallet_kwargs = {"name": args.wallet_name}
+    if (args.wallet_path or "").strip():
+        wallet_kwargs["path"] = os.path.abspath(os.path.expanduser(args.wallet_path.strip()))
+    wallet = Wallet(**wallet_kwargs)
+    try:
+        keypair = wallet.get_coldkey(password)
+    except Exception as e:
+        print(f"Error loading coldkey: {e}", file=sys.stderr)
+        print(
+            "Tip: Use the same --wallet.name as your miner (the wallet that has the coldkey). "
+            "If the miner uses a custom wallet directory, set --wallet.path or WALLET_PATH.",
+            file=sys.stderr,
+        )
+        return 1
+
+    coldkey_ss58 = keypair.ss58_address
+    print(f"Using coldkey: {coldkey_ss58}")
+
+    signature_bytes = keypair.sign(api_key.encode("utf-8"))
+    signature_hex = signature_bytes.hex()
+
+    url = args.base_url.rstrip("/") + DESEARCH_LINK_PATH
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "coldkey_ss58": coldkey_ss58,
+        "signature_hex": signature_hex,
+    }
+
+    print("Linking miner to Desearch account...")
+    try:
+        response = requests.post(url, json=payload, headers=headers, timeout=30)
+    except requests.RequestException as e:
+        print(f"Error calling Desearch: {e}", file=sys.stderr)
+        return 1
+
+    print(f"\nResponse from {DESEARCH_LINK_PATH} [{response.status_code}]:")
+    print(response.text)
+    if response.status_code >= 400:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/link_desearch_miner.py
+++ b/utils/link_desearch_miner.py
@@ -121,7 +121,7 @@ def main() -> int:
 
     url = args.base_url.rstrip("/") + DESEARCH_LINK_PATH
     headers = {
-        "Authorization": f"Bearer {api_key}",
+        "Authorization": api_key,
         "Content-Type": "application/json",
     }
     payload = {

--- a/utils/test_desearch_verify.py
+++ b/utils/test_desearch_verify.py
@@ -60,7 +60,7 @@ def main() -> int:
     headers = {
         "Accept": "application/json",
         "Content-Type": "application/json",
-        "Authorization": f"Bearer {api_key}",
+        "Authorization": api_key,
         "X-Coldkey": coldkey,
     }
 

--- a/utils/test_desearch_verify.py
+++ b/utils/test_desearch_verify.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Test flow: call Desearch API (like the miner), get response + proof headers,
+then run verify_proof (like the validator). Use this to confirm the proof
+verification path end-to-end.
+
+Usage:
+  Set DESEARCH_API_KEY in env (and ensure this coldkey is linked to your Desearch account).
+  Then run:
+
+    python -m utils.test_desearch_verify
+    python -m utils.test_desearch_verify --coldkey 5CdQ3YfmGPJojVahShC2EyT9rUmThecZQiiLquDKVNYCGhbX --statement "test query"
+
+  Default coldkey for verification: 5CdQ3YfmGPJojVahShC2EyT9rUmThecZQiiLquDKVNYCGhbX
+"""
+import argparse
+import os
+import sys
+from urllib.parse import urlencode
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Default coldkey (public key) for verification when testing
+DEFAULT_TEST_COLDKEY = "5CdQ3YfmGPJojVahShC2EyT9rUmThecZQiiLquDKVNYCGhbX"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Call Desearch API, get proof headers, run verify_proof (test miner → validator flow)."
+    )
+    parser.add_argument(
+        "--coldkey",
+        default=os.environ.get("DESEARCH_COLDKEY_SS58", DEFAULT_TEST_COLDKEY),
+        help=f"Coldkey SS58 for X-Coldkey and for verify_proof (default: {DEFAULT_TEST_COLDKEY[:20]}...).",
+    )
+    parser.add_argument(
+        "--statement",
+        default="test query for proof verification",
+        help="Search query sent to Desearch /web.",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=os.environ.get("DESEARCH_BASE_URL", "https://api.desearch.ai"),
+        help="Desearch API base URL.",
+    )
+    args = parser.parse_args()
+
+    api_key = (os.environ.get("DESEARCH_API_KEY") or "").strip()
+    if not api_key:
+        print("ERROR: DESEARCH_API_KEY not set. Set it in env or .env.", file=sys.stderr)
+        return 1
+
+    coldkey = args.coldkey.strip()
+    base_url = args.base_url.rstrip("/")
+    path = "/web"
+    params = {"num": 10, "start": 0, "query": args.statement}
+    url = f"{base_url}{path}?{urlencode(params)}"
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+        "X-Coldkey": coldkey,
+    }
+
+    try:
+        import requests
+    except ImportError:
+        print("ERROR: requests not found. pip install requests", file=sys.stderr)
+        return 1
+
+    print(f"Calling Desearch: GET {url}")
+    print(f"X-Coldkey: {coldkey[:20]}...")
+    try:
+        resp = requests.get(url, headers=headers, timeout=30)
+    except Exception as e:
+        print(f"ERROR: Desearch request failed: {e}", file=sys.stderr)
+        return 1
+
+    body_bytes = resp.content
+    sig = resp.headers.get("X-Proof-Signature", "")
+    ts = resp.headers.get("X-Proof-Timestamp", "")
+    exp = resp.headers.get("X-Proof-Expiry", "")
+
+    print(f"Response: status={resp.status_code} body_len={len(body_bytes)}")
+    print(f"X-Proof-Signature: len={len(sig)}")
+    print(f"X-Proof-Timestamp: {ts!r}")
+    print(f"X-Proof-Expiry: {exp!r}")
+
+    if resp.status_code != 200:
+        print(f"ERROR: Desearch returned {resp.status_code}. Body preview: {body_bytes[:200]!r}", file=sys.stderr)
+        return 1
+    if not (sig and ts and exp):
+        print("ERROR: Missing proof headers (401 or Desearch not returning proof).", file=sys.stderr)
+        return 1
+
+    from shared.desearch_proof import verify_proof
+
+    print("\nRunning verify_proof(coldkey=..., response_body=..., signature_hex, timestamp, expiry)...")
+    valid = verify_proof(
+        coldkey=coldkey,
+        response_body=body_bytes,
+        signature_hex=sig,
+        timestamp=ts,
+        expiry=exp,
+    )
+    if valid:
+        print("Result: Signature valid YES (validator would accept this proof).")
+        return 0
+    else:
+        print("Result: Signature valid NO (validator would reject this proof).")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/validate_desearch_signature.py
+++ b/utils/validate_desearch_signature.py
@@ -1,0 +1,107 @@
+"""
+Utility to run the Desearch miner's veridex_forward and simulate validator-side
+signature verification. Confirms that the proof returned by the miner verifies
+with the miner's coldkey (same logic as validator/api_server.py).
+
+Usage:
+  Pass the miner coldkey (wallet address) via --coldkey or DESEARCH_COLDKEY_SS58.
+  With coldkey set, wallet/subtensor are not loaded (no btcli wallet needed).
+
+  python -m utils.validate_desearch_signature --coldkey <SS58> [--statement "your query"] [--request-id id]
+
+  Or use wallet: omit --coldkey and pass wallet args so the miner loads coldkey from wallet.
+
+Requires:
+  - DESEARCH_API_KEY in env (or .env)
+  - Miner coldkey: either --coldkey / DESEARCH_COLDKEY_SS58 or wallet (same as miner).
+"""
+import argparse
+import base64
+import os
+import sys
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from shared.desearch_proof import verify_proof
+from shared.veridex_protocol import VericoreSynapse
+
+
+def main() -> int:
+    # Parse our args first; set coldkey in env so miner can use it without wallet
+    our_parser = argparse.ArgumentParser(
+        description="Run miner veridex_forward and validate Desearch proof as validator would."
+    )
+    our_parser.add_argument(
+        "--coldkey",
+        type=str,
+        default=os.environ.get("DESEARCH_COLDKEY_SS58", ""),
+        help="Miner coldkey SS58 (wallet address). Uses DESEARCH_COLDKEY_SS58 env if not set.",
+    )
+    our_parser.add_argument(
+        "--statement",
+        type=str,
+        default="test statement for signature validation",
+        help="Statement to send to Desearch (miner forwards this).",
+    )
+    our_parser.add_argument(
+        "--request-id",
+        type=str,
+        default="validate-desearch-signature",
+        help="Request ID for the synthetic synapse.",
+    )
+    args, remaining_argv = our_parser.parse_known_args()
+    if args.coldkey:
+        os.environ["DESEARCH_COLDKEY_SS58"] = args.coldkey.strip()
+    sys.argv = [sys.argv[0]] + remaining_argv
+
+    from miner.desearch.miner import Miner
+
+    miner = Miner()
+    if not miner.coldkey_ss58:
+        print(
+            "ERROR: No coldkey. Pass --coldkey <SS58> or set DESEARCH_COLDKEY_SS58, or use wallet args.",
+            file=sys.stderr,
+        )
+        return 1
+    if not os.environ.get("DESEARCH_API_KEY"):
+        print("ERROR: DESEARCH_API_KEY not set. Set it in env or .env.", file=sys.stderr)
+        return 1
+
+    synapse = VericoreSynapse(statement=args.statement, request_id=args.request_id)
+    miner.veridex_forward(synapse)
+
+    desearch = getattr(synapse, "desearch", None)
+    if not desearch or not desearch.response_body or not desearch.proof:
+        print("No Desearch proof on synapse (empty response or missing proof headers).")
+        return 0
+
+    proof = desearch.proof
+    if not (proof.signature and proof.timestamp and proof.expiry):
+        print("Desearch proof incomplete (missing signature, timestamp, or expiry).")
+        return 1
+
+    try:
+        response_body_bytes = base64.b64decode(desearch.response_body)
+    except Exception as e:
+        print(f"Failed to decode response_body: {e}")
+        return 1
+
+    valid = verify_proof(
+        coldkey=miner.coldkey_ss58,
+        response_body=response_body_bytes,
+        signature_hex=proof.signature,
+        timestamp=proof.timestamp,
+        expiry=proof.expiry,
+    )
+    if valid:
+        print("Signature valid: YES (validator would accept this proof).")
+        return 0
+    else:
+        print("Signature valid: NO (validator would reject this proof).")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/validate_desearch_signature.py
+++ b/utils/validate_desearch_signature.py
@@ -72,8 +72,14 @@ def main() -> int:
     synapse = VericoreSynapse(statement=args.statement, request_id=args.request_id)
     miner.veridex_forward(synapse)
 
-    desearch = getattr(synapse, "desearch", None)
-    if not desearch or not desearch.response_body or not desearch.proof:
+    raw_desearch = getattr(synapse, "desearch", [])
+    desearch_list = raw_desearch if isinstance(raw_desearch, list) else []
+    if not desearch_list:
+        print("No Desearch proof on synapse (empty response or missing proof headers).")
+        return 0
+
+    desearch = desearch_list[0]
+    if not desearch.response_body or not desearch.proof:
         print("No Desearch proof on synapse (empty response or missing proof headers).")
         return 0
 

--- a/validator/api_server.py
+++ b/validator/api_server.py
@@ -504,6 +504,9 @@ class APIQueryHandler:
                             all_valid = False
                             break
                     desearch_proof_valid = all_valid and len(desearch_response_bodies) == len(desearch_list)
+            # When any proof failed, do not pass partial bodies: no desearch snippet may pass evidence-in-body
+            if not desearch_proof_valid:
+                desearch_response_bodies = []
 
             # Create tasks
             tasks = [
@@ -559,21 +562,22 @@ class APIQueryHandler:
                 if statement_response.snippet_found:
                     evidence = veridex_response[i] if i < len(veridex_response) else None
                     is_desearch = evidence is not None and evidence.source_type == SourceType.DESEARCH.value
+                    # Normalize domain for case-insensitive diversity and social checks (avoids bypass via e.g. Example.COM vs example.com)
+                    domain_lower = (statement_response.domain or "").lower()
 
                     if is_desearch:
-                        domain_lower = (statement_response.domain or "").lower()
                         is_social_domain = domain_lower in SOCIAL_BONUS_DOMAINS_X or domain_lower == SOCIAL_BONUS_DOMAIN_REDDIT_NAME
                         if is_social_domain:
                             # Desearch only: x.com, twitter.com, reddit.com get no duplicate-domain penalty; domain_factor = 1
                             domain_factor = 1.0
                         else:
-                            times_used = domain_seen_count.get(statement_response.domain, 0)
-                            domain_seen_count[statement_response.domain] = times_used + 1
+                            times_used = domain_seen_count.get(domain_lower, 0)
+                            domain_seen_count[domain_lower] = times_used + 1
                             domain_factor = 1.0 / (2**times_used)
                     else:
                         # Web: first use 1.0, second 0.5, third 0.25; etc.
-                        times_used = domain_seen_count.get(statement_response.domain, 0)
-                        domain_seen_count[statement_response.domain] = times_used + 1
+                        times_used = domain_seen_count.get(domain_lower, 0)
+                        domain_seen_count[domain_lower] = times_used + 1
                         domain_factor = 1.0 / (2**times_used)
                     if statement_response.context_similarity_score < 0:
                         statement_response.context_similarity_score = 0

--- a/validator/api_server.py
+++ b/validator/api_server.py
@@ -995,7 +995,6 @@ class JWTAuthMiddleware(BaseHTTPMiddleware):
         # OPTIONS preflight requests do not send Authorization; let them through so CORSMiddleware can respond
         if request.method == "OPTIONS":
             return await call_next(request)
-        return await call_next(request)
 
         auth = request.headers.get("Authorization")
         if not auth:
@@ -1092,7 +1091,7 @@ class JWTAuthMiddleware(BaseHTTPMiddleware):
         bt.logging.info(f"JWT auth: valid JWT accepted for {request.url.path}")
         return await call_next(request)
 
-
+# Disable JWT auth for testing
 app.add_middleware(JWTAuthMiddleware)
 
 

--- a/validator/api_server.py
+++ b/validator/api_server.py
@@ -557,10 +557,24 @@ class APIQueryHandler:
             veridex_response = miner_response.synapse.veridex_response or []
             for i, statement_response in enumerate(vericore_statement_responses):
                 if statement_response.snippet_found:
-                    # First use of domain: no penalty (factor 1.0); second use 0.5; third 0.25; etc.
-                    times_used = domain_seen_count.get(statement_response.domain, 0)
-                    domain_seen_count[statement_response.domain] = times_used + 1
-                    domain_factor = 1.0 / (2**times_used)
+                    evidence = veridex_response[i] if i < len(veridex_response) else None
+                    is_desearch = evidence is not None and evidence.source_type == SourceType.DESEARCH.value
+
+                    if is_desearch:
+                        domain_lower = (statement_response.domain or "").lower()
+                        is_social_domain = domain_lower in SOCIAL_BONUS_DOMAINS_X or domain_lower == SOCIAL_BONUS_DOMAIN_REDDIT_NAME
+                        if is_social_domain:
+                            # Desearch only: x.com, twitter.com, reddit.com get no duplicate-domain penalty; domain_factor = 1
+                            domain_factor = 1.0
+                        else:
+                            times_used = domain_seen_count.get(statement_response.domain, 0)
+                            domain_seen_count[statement_response.domain] = times_used + 1
+                            domain_factor = 1.0 / (2**times_used)
+                    else:
+                        # Web: first use 1.0, second 0.5, third 0.25; etc.
+                        times_used = domain_seen_count.get(statement_response.domain, 0)
+                        domain_seen_count[statement_response.domain] = times_used + 1
+                        domain_factor = 1.0 / (2**times_used)
                     if statement_response.context_similarity_score < 0:
                         statement_response.context_similarity_score = 0
 
@@ -573,10 +587,7 @@ class APIQueryHandler:
                     statement_response.domain_factor = domain_factor
 
                     # Social bonus: desearch snippets only, and only when desearch proofs are valid; x.com/twitter.com → +1, reddit.com → +0.5
-                    if i < len(veridex_response):
-                        evidence = veridex_response[i]
-                        if desearch_proof_valid and evidence.source_type == SourceType.DESEARCH.value:
-                            domain_lower = (statement_response.domain or "").lower()
+                    if is_desearch and desearch_proof_valid:
                             if domain_lower in SOCIAL_BONUS_DOMAINS_X:
                                 social_bonus_total += SOCIAL_BONUS_DOMAIN_X
                                 statement_response.social_bonus_contribution = SOCIAL_BONUS_DOMAIN_X

--- a/validator/api_server.py
+++ b/validator/api_server.py
@@ -205,7 +205,7 @@ class APIQueryHandler:
         response = await self.dendrite.call(
             target_axon=target_axon, synapse=synapse, timeout=120, deserialize=True
         )
-        bt.logging.info(f"{self.my_uid} | {request_id} | {miner_uid} | Called axon {target_axon.hotkey} | Received response {response}")
+        bt.logging.info(f"{self.my_uid} | {request_id} | {miner_uid} | Called axon {target_axon.hotkey} ")
         end_time = time.time()
         elapsed = end_time - start_time + 1e-9
         veridex_response: VeridexResponse = VeridexResponse(

--- a/validator/api_server.py
+++ b/validator/api_server.py
@@ -1,3 +1,4 @@
+import base64
 import os
 import time
 import random
@@ -31,16 +32,19 @@ from shared.veridex_protocol import (
     VericoreQueryResponse,
     VericoreStatementResponse,
     SourceEvidence,
+    Desearch,
     StatementResponseTiming,
     MinerResponseTiming,
     QueryResponseTiming,
     SNIPPET_FETCHER_STATUS_NOT_RUN,
 )
+from shared.desearch_proof import verify_proof
 from shared.scores import (
     UNREACHABLE_MINER_SCORE,
     INVALID_RESPONSE_MINER_SCORE,
     NO_STATEMENTS_PROVIDED_SCORE,
-    DUPLICATE_EXACT_MINER_STATEMENTS
+    DUPLICATE_EXACT_MINER_STATEMENTS,
+    DESEARCH_SNIPPET_BONUS,
 )
 from shared.log_data import LoggerType
 from shared.proxy_log_handler import register_proxy_log_handler
@@ -266,6 +270,37 @@ class APIQueryHandler:
             )
             return miner_statement
 
+        # If any evidence is from Desearch, require synapse.desearch with full proof
+        has_desearch = any(
+            getattr(ev, "source_type", "web") == "desearch" for ev in veridex_responses
+        )
+        if has_desearch:
+            desearch = getattr(miner_response.synapse, "desearch", None)
+            if not desearch or not desearch.response_body or not desearch.proof:
+                bt.logging.warning(
+                    f"{self.my_uid} | {request_id} | {miner_uid} | Desearch evidence but synapse.desearch missing or incomplete"
+                )
+                miner_statement = VericoreMinerStatementResponse(
+                    miner_hotkey=miner_hotkey,
+                    miner_uid=miner_uid,
+                    status="desearch_proof_missing",
+                    raw_score=INVALID_RESPONSE_MINER_SCORE,
+                    final_score=INVALID_RESPONSE_MINER_SCORE,
+                )
+                return miner_statement
+            if not (desearch.proof.signature and desearch.proof.timestamp and desearch.proof.expiry):
+                bt.logging.warning(
+                    f"{self.my_uid} | {request_id} | {miner_uid} | Desearch proof fields incomplete"
+                )
+                miner_statement = VericoreMinerStatementResponse(
+                    miner_hotkey=miner_hotkey,
+                    miner_uid=miner_uid,
+                    status="desearch_proof_incomplete",
+                    raw_score=INVALID_RESPONSE_MINER_SCORE,
+                    final_score=INVALID_RESPONSE_MINER_SCORE,
+                )
+                return miner_statement
+
         # Valid statements returned
         return None
 
@@ -352,13 +387,43 @@ class APIQueryHandler:
             # Process Vericore response data
             bt.logging.info(f"{self.my_uid} | {request_id} | {miner_uid} | Verifying Miner Statements. Received {len(miner_response.synapse.veridex_response)} responses. Only Processing {MAX_MINER_RESPONSES}")
 
+            # Desearch: verify proof once per synapse and pass result to snippet validation
+            desearch_proof_valid = None
+            desearch_response_body_bytes = None
+            desearch_obj = getattr(miner_response.synapse, "desearch", None)
+            if desearch_obj and desearch_obj.response_body and desearch_obj.proof:
+                try:
+                    coldkey = ""
+                    if hasattr(self.metagraph, "coldkeys") and miner_uid < len(self.metagraph.coldkeys):
+                        coldkey = self.metagraph.coldkeys[miner_uid]
+                    else:
+                        neuron = self.metagraph.neurons[miner_uid]
+                        coldkey = getattr(neuron, "coldkey", "") or ""
+                    if coldkey:
+                        desearch_response_body_bytes = base64.b64decode(desearch_obj.response_body)
+                        desearch_proof_valid = verify_proof(
+                            coldkey=coldkey,
+                            response_body=desearch_response_body_bytes,
+                            signature_hex=desearch_obj.proof.signature,
+                            timestamp=desearch_obj.proof.timestamp,
+                            expiry=desearch_obj.proof.expiry,
+                        )
+                    else:
+                        desearch_proof_valid = False
+                        bt.logging.warning(f"{self.my_uid} | {request_id} | {miner_uid} | No coldkey for miner, Desearch proof invalid")
+                except Exception as e:
+                    bt.logging.warning(f"{self.my_uid} | {request_id} | {miner_uid} | Desearch proof verification failed: {e}")
+                    desearch_proof_valid = False
+
             # Create tasks
             tasks = [
                 run_validate_miner_snippet(
                     request_id=request_id,
                     miner_uid=miner_uid,
                     original_statement=statement,
-                    miner_evidence=miner_vericore_response
+                    miner_evidence=miner_vericore_response,
+                    desearch_proof_valid=desearch_proof_valid,
+                    desearch_response_body=desearch_response_body_bytes,
                 ) for miner_vericore_response in miner_response.synapse.veridex_response[:MAX_MINER_RESPONSES]
             ]
 
@@ -418,6 +483,10 @@ class APIQueryHandler:
                         statement_response.approved_url_multiplier
                     )
                     statement_response.domain_factor = domain_factor
+                    # Desearch bonus per snippet
+                    statement_response.snippet_score += getattr(
+                        statement_response, "desearch_bonus", 0
+                    )
 
                 # Add score of all snippets
                 sum_of_snippets += statement_response.snippet_score
@@ -452,6 +521,7 @@ class APIQueryHandler:
                 max_snippet_time_secs=max(snippet_times) if snippet_times else 0,
                 snippet_count=len(snippet_times),
             )
+            total_desearch_bonus = sum(getattr(r, "desearch_bonus", 0) for r in vericore_statement_responses)
             miner_statement = VericoreMinerStatementResponse(
                 miner_hotkey=miner_hotkey,
                 miner_uid=miner_uid,
@@ -468,6 +538,7 @@ class APIQueryHandler:
                 max_snippet_time_secs=max(snippet_times) if snippet_times else 0,
                 snippet_count=len(snippet_times),
                 timing=miner_timing,
+                desearch_bonus=total_desearch_bonus,
             )
             return miner_statement
         except Exception as e:

--- a/validator/api_server.py
+++ b/validator/api_server.py
@@ -32,6 +32,7 @@ from shared.veridex_protocol import (
     VericoreQueryResponse,
     VericoreStatementResponse,
     SourceEvidence,
+    SourceType,
     Desearch,
     StatementResponseTiming,
     MinerResponseTiming,
@@ -44,8 +45,14 @@ from shared.scores import (
     INVALID_RESPONSE_MINER_SCORE,
     NO_STATEMENTS_PROVIDED_SCORE,
     DUPLICATE_EXACT_MINER_STATEMENTS,
-    DESEARCH_SNIPPET_BONUS,
+    DESEARCH_PROOF_VALID_BONUS,
+    DESEARCH_PROOF_INVALID_PENALTY,
+    SOCIAL_BONUS_DOMAIN_X,
+    SOCIAL_BONUS_DOMAIN_REDDIT,
+    SOCIAL_BONUS_DOMAINS_X,
+    SOCIAL_BONUS_DOMAIN_REDDIT_NAME,
 )
+from shared.wallet_api_key_utils import get_linked_wallet_from_payload
 from shared.log_data import LoggerType
 from shared.proxy_log_handler import register_proxy_log_handler
 from validator.snippet_validator import run_validate_miner_snippet
@@ -131,9 +138,23 @@ class APIQueryHandler:
         self.results_dir = "results"
         os.makedirs(self.results_dir, exist_ok=True)
 
+    def _sanitize_endpoint(self, s: str) -> str:
+        """Remove non-breaking space (\\xa0) and strip whitespace from endpoint URLs."""
+        if not s or not isinstance(s, str):
+            return s
+        return s.replace("\xa0", "").strip()
+
     def get_config(self):
         parser = get_parser()
         config = bt.config(parser)
+
+        # Sanitize subtensor endpoint so port/URL parsing does not fail on stray \\xa0 (e.g. from env)
+        if hasattr(config, "subtensor"):
+            for attr in ("chain_endpoint", "network"):
+                if hasattr(config.subtensor, attr):
+                    val = getattr(config.subtensor, attr)
+                    if isinstance(val, str):
+                        setattr(config.subtensor, attr, self._sanitize_endpoint(val))
 
         bt.logging.info(f"get_config: {config}")
         config.full_path = os.path.expanduser(
@@ -233,6 +254,61 @@ class APIQueryHandler:
         # miner is reachable
         return None
 
+    def _validate_desearch_evidence(
+        self,
+        miner_uid: int,
+        miner_hotkey: str,
+        request_id: str,
+        veridex_responses: List[SourceEvidence],
+        raw_desearch,
+    ) -> VericoreMinerStatementResponse | None:
+        """
+        If any evidence is from Desearch, require desearch (list) with full proof for every item.
+        Returns an error VericoreMinerStatementResponse on failure, or None if no desearch evidence or validation passes.
+        """
+        has_desearch = any(
+            getattr(ev, "source_type", SourceType.WEB.value) == SourceType.DESEARCH.value for ev in veridex_responses
+        )
+        if not has_desearch:
+            return None
+        desearch_list = raw_desearch if isinstance(raw_desearch, list) else []
+        if not desearch_list:
+            bt.logging.warning(
+                f"{self.my_uid} | {request_id} | {miner_uid} | Desearch evidence but synapse.desearch missing or empty"
+            )
+            return VericoreMinerStatementResponse(
+                miner_hotkey=miner_hotkey,
+                miner_uid=miner_uid,
+                status="desearch_proof_missing",
+                raw_score=INVALID_RESPONSE_MINER_SCORE,
+                final_score=INVALID_RESPONSE_MINER_SCORE,
+            )
+        for item in desearch_list:
+            if not item or not getattr(item, "response_body", None) or not getattr(item, "proof", None):
+                bt.logging.warning(
+                    f"{self.my_uid} | {request_id} | {miner_uid} | Desearch evidence but synapse.desearch item missing body or proof"
+                )
+                return VericoreMinerStatementResponse(
+                    miner_hotkey=miner_hotkey,
+                    miner_uid=miner_uid,
+                    status="desearch_proof_missing",
+                    raw_score=INVALID_RESPONSE_MINER_SCORE,
+                    final_score=INVALID_RESPONSE_MINER_SCORE,
+                )
+            p = getattr(item, "proof", None)
+            if not (p and getattr(p, "signature", None) and getattr(p, "timestamp", None) and getattr(p, "expiry", None)):
+                bt.logging.warning(
+                    f"{self.my_uid} | {request_id} | {miner_uid} | Desearch proof fields incomplete"
+                )
+                return VericoreMinerStatementResponse(
+                    miner_hotkey=miner_hotkey,
+                    miner_uid=miner_uid,
+                    status="desearch_proof_incomplete",
+                    raw_score=INVALID_RESPONSE_MINER_SCORE,
+                    final_score=INVALID_RESPONSE_MINER_SCORE,
+                )
+        return None
+
     def validate_miner_response(
         self,
         miner_uid: int,
@@ -270,36 +346,15 @@ class APIQueryHandler:
             )
             return miner_statement
 
-        # If any evidence is from Desearch, require synapse.desearch with full proof
-        has_desearch = any(
-            getattr(ev, "source_type", "web") == "desearch" for ev in veridex_responses
+        desearch_error = self._validate_desearch_evidence(
+            miner_uid,
+            miner_hotkey,
+            request_id,
+            veridex_responses,
+            getattr(miner_response.synapse, "desearch", None),
         )
-        if has_desearch:
-            desearch = getattr(miner_response.synapse, "desearch", None)
-            if not desearch or not desearch.response_body or not desearch.proof:
-                bt.logging.warning(
-                    f"{self.my_uid} | {request_id} | {miner_uid} | Desearch evidence but synapse.desearch missing or incomplete"
-                )
-                miner_statement = VericoreMinerStatementResponse(
-                    miner_hotkey=miner_hotkey,
-                    miner_uid=miner_uid,
-                    status="desearch_proof_missing",
-                    raw_score=INVALID_RESPONSE_MINER_SCORE,
-                    final_score=INVALID_RESPONSE_MINER_SCORE,
-                )
-                return miner_statement
-            if not (desearch.proof.signature and desearch.proof.timestamp and desearch.proof.expiry):
-                bt.logging.warning(
-                    f"{self.my_uid} | {request_id} | {miner_uid} | Desearch proof fields incomplete"
-                )
-                miner_statement = VericoreMinerStatementResponse(
-                    miner_hotkey=miner_hotkey,
-                    miner_uid=miner_uid,
-                    status="desearch_proof_incomplete",
-                    raw_score=INVALID_RESPONSE_MINER_SCORE,
-                    final_score=INVALID_RESPONSE_MINER_SCORE,
-                )
-                return miner_statement
+        if desearch_error is not None:
+            return desearch_error
 
         # Valid statements returned
         return None
@@ -385,35 +440,70 @@ class APIQueryHandler:
 
 
             # Process Vericore response data
-            bt.logging.info(f"{self.my_uid} | {request_id} | {miner_uid} | Verifying Miner Statements. Received {len(miner_response.synapse.veridex_response)} responses. Only Processing {MAX_MINER_RESPONSES}")
+            veridex_resp = miner_response.synapse.veridex_response or []
+            bt.logging.info(f"{self.my_uid} | {request_id} | {miner_uid} | Verifying Miner Statements. Received {len(veridex_resp)} responses. Only Processing {MAX_MINER_RESPONSES}")
 
-            # Desearch: verify proof once per synapse and pass result to snippet validation
-            desearch_proof_valid = None
-            desearch_response_body_bytes = None
-            desearch_obj = getattr(miner_response.synapse, "desearch", None)
-            if desearch_obj and desearch_obj.response_body and desearch_obj.proof:
-                try:
-                    coldkey = ""
-                    if hasattr(self.metagraph, "coldkeys") and miner_uid < len(self.metagraph.coldkeys):
-                        coldkey = self.metagraph.coldkeys[miner_uid]
-                    else:
-                        neuron = self.metagraph.neurons[miner_uid]
-                        coldkey = getattr(neuron, "coldkey", "") or ""
-                    if coldkey:
-                        desearch_response_body_bytes = base64.b64decode(desearch_obj.response_body)
-                        desearch_proof_valid = verify_proof(
-                            coldkey=coldkey,
-                            response_body=desearch_response_body_bytes,
-                            signature_hex=desearch_obj.proof.signature,
-                            timestamp=desearch_obj.proof.timestamp,
-                            expiry=desearch_obj.proof.expiry,
+            # Log what we received from miner
+            for i, ev in enumerate(veridex_resp[:MAX_MINER_RESPONSES]):
+                url = getattr(ev, "url", "") or ""
+                stype = getattr(ev, "source_type", SourceType.WEB.value)
+                excerpt = (getattr(ev, "excerpt", "") or "")[:80]
+                bt.logging.info(
+                    f"{self.my_uid} | {request_id} | {miner_uid} | miner_response[{i}] url={url[:60]}... source_type={stype} excerpt={excerpt!r}..."
+                )
+            raw_desearch = getattr(miner_response.synapse, "desearch", None)
+            desearch_list = raw_desearch if isinstance(raw_desearch, list) else []
+            if desearch_list:
+                for idx, d in enumerate(desearch_list):
+                    if d and getattr(d, "response_body", None) and getattr(d, "proof", None):
+                        p = getattr(d, "proof", None)
+                        bt.logging.info(
+                            f"{self.my_uid} | {request_id} | {miner_uid} | miner_response desearch[{idx}]: response_body_b64_len={len(d.response_body)} "
+                            f"proof.signature_len={len(getattr(p, 'signature', '') or '')} timestamp={getattr(p, 'timestamp', '')!r} expiry={getattr(p, 'expiry', '')!r}"
                         )
                     else:
-                        desearch_proof_valid = False
-                        bt.logging.warning(f"{self.my_uid} | {request_id} | {miner_uid} | No coldkey for miner, Desearch proof invalid")
-                except Exception as e:
-                    bt.logging.warning(f"{self.my_uid} | {request_id} | {miner_uid} | Desearch proof verification failed: {e}")
-                    desearch_proof_valid = False
+                        bt.logging.info(f"{self.my_uid} | {request_id} | {miner_uid} | miner_response desearch[{idx}]: absent or incomplete")
+            else:
+                bt.logging.info(f"{self.my_uid} | {request_id} | {miner_uid} | miner_response desearch: absent or empty")
+            bt.logging.info(f"{self.my_uid} | {request_id} | {miner_uid} | miner_response elapse_time={getattr(miner_response, 'elapse_time', None)}")
+
+            # Desearch: verify every proof and collect all response bodies
+            desearch_proof_valid = False
+            desearch_response_bodies: List[bytes] = []
+            if desearch_list:
+                coldkey = ""
+                if hasattr(self.metagraph, "coldkeys") and miner_uid < len(self.metagraph.coldkeys):
+                    coldkey = self.metagraph.coldkeys[miner_uid]
+                else:
+                    neuron_obj = self.metagraph.neurons[miner_uid]
+                    coldkey = getattr(neuron_obj, "coldkey", "") or ""
+                if not coldkey:
+                    bt.logging.warning(f"{self.my_uid} | {request_id} | {miner_uid} | No coldkey for miner, Desearch proof invalid")
+                else:
+                    all_valid = True
+                    for d in desearch_list:
+                        if not d or not getattr(d, "response_body", None) or not getattr(d, "proof", None):
+                            all_valid = False
+                            break
+                        try:
+                            body_bytes = base64.b64decode(d.response_body)
+                            ok = verify_proof(
+                                coldkey=coldkey,
+                                response_body=body_bytes,
+                                signature_hex=d.proof.signature,
+                                timestamp=d.proof.timestamp,
+                                expiry=d.proof.expiry,
+                            )
+                            if ok:
+                                desearch_response_bodies.append(body_bytes)
+                            else:
+                                all_valid = False
+                                break
+                        except Exception as e:
+                            bt.logging.warning(f"{self.my_uid} | {request_id} | {miner_uid} | Desearch proof verification failed: {e}")
+                            all_valid = False
+                            break
+                    desearch_proof_valid = all_valid and len(desearch_response_bodies) == len(desearch_list)
 
             # Create tasks
             tasks = [
@@ -422,8 +512,7 @@ class APIQueryHandler:
                     miner_uid=miner_uid,
                     original_statement=statement,
                     miner_evidence=miner_vericore_response,
-                    desearch_proof_valid=desearch_proof_valid,
-                    desearch_response_body=desearch_response_body_bytes,
+                    desearch_response_bodies=desearch_response_bodies,
                 ) for miner_vericore_response in miner_response.synapse.veridex_response[:MAX_MINER_RESPONSES]
             ]
 
@@ -457,21 +546,20 @@ class APIQueryHandler:
 
             bt.logging.info(f"{self.my_uid} | {request_id} | {miner_uid} | Scoring Miner Statements Based on Snippets")
 
-            domain_counts = {}
-
             bt.logging.info(f"{self.my_uid} | {request_id} | {miner_uid} | Calculating miner scores")
 
-            # Check how many times the domain count was reused
-            for statement_response in vericore_statement_responses:
-                if statement_response.snippet_found:
-                    domain_counts[statement_response.domain] = domain_counts.get(statement_response.domain, 0) + 1
+            # Per-domain count of how many times we've seen this domain so far (first use = no penalty, then 0.5, 0.25, ...)
+            domain_seen_count: dict[str, int] = {}
 
             # Calculate the miner's statement score
             sum_of_snippets = 0
-            for statement_response in vericore_statement_responses:
+            social_bonus_total = 0.0
+            veridex_response = miner_response.synapse.veridex_response or []
+            for i, statement_response in enumerate(vericore_statement_responses):
                 if statement_response.snippet_found:
-                    # Use times_used - 1 since we want first use to have no penalty
-                    times_used = domain_counts.get(statement_response.domain, 1) - 1
+                    # First use of domain: no penalty (factor 1.0); second use 0.5; third 0.25; etc.
+                    times_used = domain_seen_count.get(statement_response.domain, 0)
+                    domain_seen_count[statement_response.domain] = times_used + 1
                     domain_factor = 1.0 / (2**times_used)
                     if statement_response.context_similarity_score < 0:
                         statement_response.context_similarity_score = 0
@@ -483,10 +571,18 @@ class APIQueryHandler:
                         statement_response.approved_url_multiplier
                     )
                     statement_response.domain_factor = domain_factor
-                    # Desearch bonus per snippet
-                    statement_response.snippet_score += getattr(
-                        statement_response, "desearch_bonus", 0
-                    )
+
+                    # Social bonus: desearch snippets only, and only when desearch proofs are valid; x.com/twitter.com → +1, reddit.com → +0.5
+                    if i < len(veridex_response):
+                        evidence = veridex_response[i]
+                        if desearch_proof_valid and evidence.source_type == SourceType.DESEARCH.value:
+                            domain_lower = (statement_response.domain or "").lower()
+                            if domain_lower in SOCIAL_BONUS_DOMAINS_X:
+                                social_bonus_total += SOCIAL_BONUS_DOMAIN_X
+                                statement_response.social_bonus_contribution = SOCIAL_BONUS_DOMAIN_X
+                            elif domain_lower == SOCIAL_BONUS_DOMAIN_REDDIT_NAME:
+                                social_bonus_total += SOCIAL_BONUS_DOMAIN_REDDIT
+                                statement_response.social_bonus_contribution = SOCIAL_BONUS_DOMAIN_REDDIT
 
                 # Add score of all snippets
                 sum_of_snippets += statement_response.snippet_score
@@ -494,9 +590,17 @@ class APIQueryHandler:
             # Calculate final score considering speed factor
             speed_factor = self.calculate_speed_factor(miner_response.elapse_time)
 
+            # Miner-level desearch proof bonus/penalty (applied once, not per snippet)
+            desearch_adjustment = 0
+            if desearch_list:
+                if desearch_proof_valid:
+                    desearch_adjustment = DESEARCH_PROOF_VALID_BONUS
+                else:
+                    desearch_adjustment = DESEARCH_PROOF_INVALID_PENALTY
+
             bt.logging.info(f"{self.my_uid} | {request_id} | {miner_uid} | Calculated Speed Factor: {speed_factor} | Miner response: {miner_response.elapse_time}")
-            final_score = sum_of_snippets * speed_factor
-            bt.logging.info(f"{self.my_uid} | {request_id} | {miner_uid} | Final Score: {final_score} | Sum Of Snippets: {sum_of_snippets}")
+            final_score = (sum_of_snippets * speed_factor) + desearch_adjustment + social_bonus_total
+            bt.logging.info(f"{self.my_uid} | {request_id} | {miner_uid} | Final Score: {final_score} | Sum Of Snippets: {sum_of_snippets} | Desearch Adjustment: {desearch_adjustment} | Social Bonus: {social_bonus_total}")
             if is_test and is_nonsense and final_score > 0.5:
                 final_score -= 1.0
 
@@ -521,7 +625,6 @@ class APIQueryHandler:
                 max_snippet_time_secs=max(snippet_times) if snippet_times else 0,
                 snippet_count=len(snippet_times),
             )
-            total_desearch_bonus = sum(getattr(r, "desearch_bonus", 0) for r in vericore_statement_responses)
             miner_statement = VericoreMinerStatementResponse(
                 miner_hotkey=miner_hotkey,
                 miner_uid=miner_uid,
@@ -538,7 +641,8 @@ class APIQueryHandler:
                 max_snippet_time_secs=max(snippet_times) if snippet_times else 0,
                 snippet_count=len(snippet_times),
                 timing=miner_timing,
-                desearch_bonus=total_desearch_bonus,
+                desearch_bonus_score=desearch_adjustment,
+                social_bonus_score=social_bonus_total,
             )
             return miner_statement
         except Exception as e:
@@ -880,6 +984,8 @@ class JWTAuthMiddleware(BaseHTTPMiddleware):
         # OPTIONS preflight requests do not send Authorization; let them through so CORSMiddleware can respond
         if request.method == "OPTIONS":
             return await call_next(request)
+        return await call_next(request)
+
         auth = request.headers.get("Authorization")
         if not auth:
             bt.logging.warning(
@@ -929,6 +1035,8 @@ class JWTAuthMiddleware(BaseHTTPMiddleware):
                     content={"detail": "Invalid or expired token"},
                     status_code=401,
                 )
+            # Expose linked wallet (if present) for endpoints that need wallet attribution
+            request.state.linked_wallet = get_linked_wallet_from_payload(payload)
         except jwt.ExpiredSignatureError as e:
             bt.logging.warning(
                 f"JWT auth: 401 for {request.url.path} — token expired: {e}"

--- a/validator/snippet_validator.py
+++ b/validator/snippet_validator.py
@@ -418,12 +418,11 @@ class SnippetValidator:
         response: VericoreStatementResponse,
         start_time: float,
     ) -> VericoreStatementResponse:
-        """Set verify_miner_time_taken_secs on response (and timing) from start_time. Only set when snippet_found (success); leave 0 for errors."""
-        if response.snippet_found:
-            elapsed = time.perf_counter() - start_time
-            response.verify_miner_time_taken_secs = elapsed
-            if response.timing is not None:
-                response.timing.verify_miner_time_taken_secs = elapsed
+        """Set verify_miner_time_taken_secs on response (and timing) from start_time. Always set regardless of snippet_found."""
+        elapsed = time.perf_counter() - start_time
+        response.verify_miner_time_taken_secs = elapsed
+        if response.timing is not None:
+            response.timing.verify_miner_time_taken_secs = elapsed
         return response
 
     def _create_invalid_statement_response(

--- a/validator/snippet_validator.py
+++ b/validator/snippet_validator.py
@@ -42,7 +42,9 @@ from shared.scores import (
     UNRELATED_PAGE_SNIPPET,
     BLACKLISTED_URL_SCORE,
     INVALID_SNIPPET_EXCERPT,
-    IS_SEARCH_WEB_PAGE, FAKE_SNIPPET
+    IS_SEARCH_WEB_PAGE,
+    FAKE_SNIPPET,
+    DESEARCH_SNIPPET_BONUS,
 )
 from validator.statement_context_evaluator import assess_statement_async
 from validator.web_page_validator import is_search_web_page
@@ -421,12 +423,28 @@ class SnippetValidator:
         #
         return True
 
+    def _evidence_in_desearch_response(
+        self, url: str, excerpt: str, response_body: bytes
+    ) -> bool:
+        """Check if url and excerpt are present in the Desearch response body (text or JSON)."""
+        try:
+            text = response_body.decode("utf-8", errors="replace")
+            if url and url not in text:
+                return False
+            if excerpt and excerpt.strip() and excerpt.strip() not in text:
+                return False
+            return True
+        except Exception:
+            return False
+
     async def validate_miner_snippet(
         self,
         request_id: str,
         miner_uid: int,
         original_statement: str,
-        miner_evidence: SourceEvidence
+        miner_evidence: SourceEvidence,
+        desearch_proof_valid: bool | None = None,
+        desearch_response_body: bytes | None = None,
     ) -> VericoreStatementResponse:
         start_time = time.perf_counter()
 
@@ -434,6 +452,56 @@ class SnippetValidator:
             f"{request_id} | {miner_uid} | {miner_evidence.url} | Verifying miner snippet"
         )
         try:
+            # Desearch: require valid proof and evidence-from-body when source_type is desearch
+            source_type = getattr(miner_evidence, "source_type", "web")
+            if source_type == "desearch":
+                verify_secs = time.perf_counter() - start_time
+                if desearch_proof_valid is not True:
+                    return VericoreStatementResponse(
+                        url=miner_evidence.url,
+                        excerpt=miner_evidence.excerpt,
+                        domain="",
+                        snippet_found=False,
+                        local_score=0.0,
+                        snippet_score=0.0,
+                        snippet_score_reason="desearch_proof_invalid",
+                        verify_miner_time_taken_secs=verify_secs,
+                        timing=StatementResponseTiming(
+                            verify_miner_time_taken_secs=verify_secs,
+                        ),
+                    )
+                if not desearch_response_body:
+                    return VericoreStatementResponse(
+                        url=miner_evidence.url,
+                        excerpt=miner_evidence.excerpt,
+                        domain="",
+                        snippet_found=False,
+                        local_score=0.0,
+                        snippet_score=0.0,
+                        snippet_score_reason="desearch_proof_invalid",
+                        verify_miner_time_taken_secs=verify_secs,
+                        timing=StatementResponseTiming(
+                            verify_miner_time_taken_secs=verify_secs,
+                        ),
+                    )
+                if not self._evidence_in_desearch_response(
+                    miner_evidence.url, miner_evidence.excerpt, desearch_response_body
+                ):
+                    return VericoreStatementResponse(
+                        url=miner_evidence.url,
+                        excerpt=miner_evidence.excerpt,
+                        domain="",
+                        snippet_found=False,
+                        local_score=0.0,
+                        snippet_score=0.0,
+                        snippet_score_reason="desearch_evidence_not_in_response",
+                        verify_miner_time_taken_secs=verify_secs,
+                        timing=StatementResponseTiming(
+                            verify_miner_time_taken_secs=verify_secs,
+                        ),
+                    )
+                # Proof valid and evidence in body: continue to normal validation; we will add DESEARCH_SNIPPET_BONUS at the end
+
             try:
                 domain = self._extract_domain(miner_evidence.url)
             except InsecureProtocolError:
@@ -852,6 +920,7 @@ class SnippetValidator:
             end_time = time.perf_counter()
             signals = self._extract_assessment_signals(assessment_result) if assessment_result else self._extract_assessment_signals({})
             verify_secs = end_time - start_time
+            desearch_bonus = DESEARCH_SNIPPET_BONUS if source_type == "desearch" else 0.0
             vericore_miner_response = VericoreStatementResponse(
                 url=miner_evidence.url,
                 excerpt=miner_evidence.excerpt,
@@ -890,6 +959,7 @@ class SnippetValidator:
                     fetch_result.cleaning_html_time_secs,
                     fetch_result.fetch_by_http_status, fetch_result.fetch_by_selenium_status,
                 ),
+                desearch_bonus=desearch_bonus,
             )
             total_time = end_time - start_time
             other_time = total_time - fetch_page_time_taken_secs - assess_statement_time_taken_secs
@@ -929,11 +999,15 @@ async def run_validate_miner_snippet(
     request_id: str,
     miner_uid: int,
     original_statement: str,
-    miner_evidence: SourceEvidence
+    miner_evidence: SourceEvidence,
+    desearch_proof_valid: bool | None = None,
+    desearch_response_body: bytes | None = None,
 ) -> VericoreStatementResponse:
     return await validator.validate_miner_snippet(
         request_id,
         miner_uid,
         original_statement,
-        miner_evidence
+        miner_evidence,
+        desearch_proof_valid=desearch_proof_valid,
+        desearch_response_body=desearch_response_body,
     )

--- a/validator/snippet_validator.py
+++ b/validator/snippet_validator.py
@@ -1,5 +1,7 @@
 import time
+import typing
 import unicodedata
+from dataclasses import dataclass
 import bittensor as bt
 import tldextract
 import ipaddress
@@ -16,6 +18,7 @@ from shared.exceptions import InsecureProtocolError
 from shared.top_site_cache import is_approved_site
 from shared.veridex_protocol import (
     SourceEvidence,
+    SourceType,
     VericoreStatementResponse,
     FetchPageResult,
     StatementResponseTiming,
@@ -44,12 +47,20 @@ from shared.scores import (
     INVALID_SNIPPET_EXCERPT,
     IS_SEARCH_WEB_PAGE,
     FAKE_SNIPPET,
-    DESEARCH_SNIPPET_BONUS,
+    DESEARCH_EVIDENCE_NOT_IN_RESPONSE,
 )
 from validator.statement_context_evaluator import assess_statement_async
 from validator.web_page_validator import is_search_web_page
 
 MIN_SNIPPET_CONTEXT_SIMILARITY_SCORE = .65
+
+
+@dataclass
+class StatementExcerptCheckResult:
+    """Result of _check_statement_excerpt. If early_exit_response is set, return it; else continue with is_similar_excerpt and statement_similarity_score."""
+    early_exit_response: VericoreStatementResponse | None
+    is_similar_excerpt: bool | None
+    statement_similarity_score: float | None
 
 # Snippet-in-page verification: fuzzy fallback when exact (normalized) match fails
 FUZZY_VERIFY_THRESHOLD = 0.94  # ratio in [0, 1]; only accept if best match >= this (character-level tolerance only)
@@ -230,18 +241,10 @@ class SnippetValidator:
             # Using search as evidence - 5
             if is_similar_excerpt:
                 bt.logging.info(f"{request_id} | {miner_uid} | {miner_evidence.url} | {values[0]} | Query Parameter Excerpt is the SAME")
-                snippet_score = USING_SEARCH_AS_EVIDENCE
-                vericore_miner_response = VericoreStatementResponse(
-                    url=miner_evidence.url,
-                    excerpt=miner_evidence.excerpt,
-                    domain=domain,
-                    snippet_found=False,
-                    local_score=0.0,
-                    snippet_score=snippet_score,
-                    snippet_score_reason=f"query_parameter_same_as_evidence ({statement_similarity_score})",
-                    timing=StatementResponseTiming(),
+                return self._create_invalid_statement_response(
+                    miner_evidence, domain, USING_SEARCH_AS_EVIDENCE,
+                    f"query_parameter_same_as_evidence ({statement_similarity_score})",
                 )
-                return vericore_miner_response
 
         parsed = urlparse(miner_evidence.url)
         path_parts = [unquote_plus(part.strip()) for part in parsed.path.split('/') if part]
@@ -250,16 +253,8 @@ class SnippetValidator:
             if part.lower() == "search":
             # if re.search(r"[\\/]*search[\\/]*", part):
                 bt.logging.info(f"{request_id} | {miner_uid} | {miner_evidence.url} | {part} | search is part of url")
-                snippet_score = USING_SEARCH_AS_EVIDENCE
-                return VericoreStatementResponse(
-                    url=miner_evidence.url,
-                    excerpt=miner_evidence.excerpt,
-                    domain=domain,
-                    snippet_found=False,
-                    local_score=0.0,
-                    snippet_score=snippet_score,
-                    snippet_score_reason="using_search_in_url_as_evidence",
-                    timing=StatementResponseTiming(),
+                return self._create_invalid_statement_response(
+                    miner_evidence, domain, USING_SEARCH_AS_EVIDENCE, "using_search_in_url_as_evidence"
                 )
 
             if part_index == len(path_parts) - 1:
@@ -268,30 +263,14 @@ class SnippetValidator:
 
                 if word_count > 3:
                     bt.logging.info(f"{request_id} | {miner_uid} | {miner_evidence.url} | {part} | Last url search parameter is sentence")
-                    snippet_score = USING_SEARCH_AS_EVIDENCE
-                    return VericoreStatementResponse(
-                        url=miner_evidence.url,
-                        excerpt=miner_evidence.excerpt,
-                        domain=domain,
-                        snippet_found=False,
-                        local_score=0.0,
-                        snippet_score=snippet_score,
-                        snippet_score_reason="using_search_as_part_of_url",
-                        timing=StatementResponseTiming(),
+                    return self._create_invalid_statement_response(
+                        miner_evidence, domain, USING_SEARCH_AS_EVIDENCE, "using_search_as_part_of_url"
                     )
 
                 if "%20" in part:
                     bt.logging.info(f"{request_id} | {miner_uid} | {miner_evidence.url} | {part} | Last url search parameter is sentence:%20 ")
-                    snippet_score = USING_SEARCH_AS_EVIDENCE
-                    return VericoreStatementResponse(
-                        url=miner_evidence.url,
-                        excerpt=miner_evidence.excerpt,
-                        domain=domain,
-                        snippet_found=False,
-                        local_score=0.0,
-                        snippet_score=snippet_score,
-                        snippet_score_reason="using_search_as_evidence:%20",
-                        timing=StatementResponseTiming(),
+                    return self._create_invalid_statement_response(
+                        miner_evidence, domain, USING_SEARCH_AS_EVIDENCE, "using_search_as_evidence:%20"
                     )
 
                 is_similar_excerpt, statement_similarity_score,  = await self.is_snippet_similar_to_statement(
@@ -299,16 +278,8 @@ class SnippetValidator:
                 )
                 if is_similar_excerpt:
                     bt.logging.info(f"{request_id} | {miner_uid} | {miner_evidence.url} | {part} | Excerpt is same as url")
-                    snippet_score = USING_SEARCH_AS_EVIDENCE
-                    return VericoreStatementResponse(
-                        url=miner_evidence.url,
-                        excerpt=miner_evidence.excerpt,
-                        domain=domain,
-                        snippet_found=False,
-                        local_score=0.0,
-                        snippet_score=snippet_score,
-                        snippet_score_reason="excerpt_is_same_as_url",
-                        timing=StatementResponseTiming(),
+                    return self._create_invalid_statement_response(
+                        miner_evidence, domain, USING_SEARCH_AS_EVIDENCE, "excerpt_is_same_as_url"
                     )
 
         # llm_response = await assess_url_as_fake(
@@ -345,16 +316,8 @@ class SnippetValidator:
 
         # Check if domain is blacklisted
         if is_blacklisted_domain(request_id=request_id, miner_uid=miner_uid, domain=domain):
-            snippet_score = BLACKLISTED_URL_SCORE
-            return VericoreStatementResponse(
-                url=miner_evidence.url,
-                excerpt=miner_evidence.excerpt,
-                domain=domain,
-                snippet_found=False,
-                local_score=0.0,
-                snippet_score=snippet_score,
-                snippet_score_reason="blacklisted_url",
-                timing=StatementResponseTiming(),
+            return self._create_invalid_statement_response(
+                miner_evidence, domain, BLACKLISTED_URL_SCORE, "blacklisted_url"
             )
 
         # check if url has query string and excerpt same as query string
@@ -376,16 +339,8 @@ class SnippetValidator:
             f"{request_id} | {miner_uid} | {miner_evidence.url} | Is domain registered recently: {domain_registered_recently}"
         )
         if domain_registered_recently:
-            snippet_score = DOMAIN_REGISTERED_RECENTLY
-            return VericoreStatementResponse(
-                url=miner_evidence.url,
-                excerpt=miner_evidence.excerpt,
-                domain=domain,
-                snippet_found=False,
-                local_score=0.0,
-                snippet_score=snippet_score,
-                snippet_score_reason="domain_is_recently_registered",
-                timing=StatementResponseTiming(),
+            return self._create_invalid_statement_response(
+                miner_evidence, domain, DOMAIN_REGISTERED_RECENTLY, "domain_is_recently_registered"
             )
 
     def is_valid_separator_sentence(self, sentence):
@@ -426,16 +381,226 @@ class SnippetValidator:
     def _evidence_in_desearch_response(
         self, url: str, excerpt: str, response_body: bytes
     ) -> bool:
-        """Check if url and excerpt are present in the Desearch response body (text or JSON)."""
+        """Check if url is present in the Desearch response body (text or JSON). Excerpt is not checked."""
         try:
-            text = response_body.decode("utf-8", errors="replace")
-            if url and url not in text:
+            if response_body is None:
                 return False
-            if excerpt and excerpt.strip() and excerpt.strip() not in text:
+            text = response_body.decode("utf-8", errors="replace") or ""
+            if url and url not in text:
                 return False
             return True
         except Exception:
             return False
+
+    async def _run_assess_statement(
+        self,
+        request_id: str,
+        miner_uid: int,
+        statement_url: str,
+        statement: str,
+        webpage: str,
+        miner_excerpt: str,
+    ) -> tuple[dict | None, float]:
+        """Run AI statement assessment. Returns (assessment_result, time_taken_secs). Reusable for web and desearch."""
+        start = time.perf_counter()
+        result = await assess_statement_async(
+            request_id=request_id,
+            miner_uid=miner_uid,
+            statement_url=statement_url,
+            statement=statement,
+            webpage=webpage,
+            miner_excerpt=miner_excerpt,
+        )
+        return result, time.perf_counter() - start
+
+    def _with_verify_time(
+        self,
+        response: VericoreStatementResponse,
+        start_time: float,
+    ) -> VericoreStatementResponse:
+        """Set verify_miner_time_taken_secs on response (and timing) from start_time. Only set when snippet_found (success); leave 0 for errors."""
+        if response.snippet_found:
+            elapsed = time.perf_counter() - start_time
+            response.verify_miner_time_taken_secs = elapsed
+            if response.timing is not None:
+                response.timing.verify_miner_time_taken_secs = elapsed
+        return response
+
+    def _create_invalid_statement_response(
+        self,
+        miner_evidence: SourceEvidence,
+        domain: str,
+        snippet_score: float,
+        snippet_score_reason: str,
+        **kwargs,
+    ) -> VericoreStatementResponse:
+        """Build an invalid VericoreStatementResponse (snippet_found=False, verify_miner_time_taken_secs=0). Pass any extra fields via kwargs."""
+        return VericoreStatementResponse(
+            url=miner_evidence.url,
+            excerpt=miner_evidence.excerpt,
+            domain=domain,
+            snippet_found=False,
+            local_score=0.0,
+            snippet_score=snippet_score,
+            snippet_score_reason=snippet_score_reason,
+            verify_miner_time_taken_secs=0,
+            timing=StatementResponseTiming(verify_miner_time_taken_secs=0),
+            **kwargs,
+        )
+
+    async def _check_statement_excerpt(
+        self,
+        request_id: str,
+        miner_uid: int,
+        original_statement: str,
+        miner_evidence: SourceEvidence,
+        domain: str,
+        check_excerpt_similarity: bool = True,
+    ) -> StatementExcerptCheckResult:
+        """
+        Shared excerpt checks: empty snippet, same-as-statement, invalid sentence.
+        If check_excerpt_similarity is True (web), also runs excerpt-too-similar check.
+        Desearch uses check_excerpt_similarity=False. Returns a StatementExcerptCheckResult;
+        when early_exit_response is set, return it; otherwise continue with the similarity fields.
+        verify_miner_time_taken_secs is left 0; caller sets it before returning if needed.
+        """
+        snippet_str = miner_evidence.excerpt.strip()
+
+        if not snippet_str:
+            return StatementExcerptCheckResult(
+                early_exit_response=self._create_invalid_statement_response(
+                    miner_evidence, domain, NO_SNIPPET_PROVIDED, "no_snippet_provided"
+                ),
+                is_similar_excerpt=None,
+                statement_similarity_score=None,
+            )
+
+        if snippet_str == original_statement.strip():
+            return StatementExcerptCheckResult(
+                early_exit_response=self._create_invalid_statement_response(
+                    miner_evidence, domain, SNIPPET_SAME_AS_STATEMENT, "snippet_same_as_statement"
+                ),
+                is_similar_excerpt=None,
+                statement_similarity_score=None,
+            )
+
+        if not self.is_valid_separator_sentence(snippet_str):
+            return StatementExcerptCheckResult(
+                early_exit_response=self._create_invalid_statement_response(
+                    miner_evidence, domain, INVALID_SNIPPET_EXCERPT, "invalid_excerpt"
+                ),
+                is_similar_excerpt=None,
+                statement_similarity_score=None,
+            )
+
+        if not check_excerpt_similarity:
+            return StatementExcerptCheckResult(early_exit_response=None, is_similar_excerpt=False, statement_similarity_score=0.0)
+
+        bt.logging.info(
+            f"{request_id} | {miner_uid} | {miner_evidence.url} | Is snippet in same context as statement"
+        )
+        is_similar_excerpt, statement_similarity_score = await self.is_snippet_similar_to_statement(
+            request_id, miner_uid, miner_evidence.url, original_statement, snippet_str
+        )
+        bt.logging.info(
+            f"{request_id} | {miner_uid} | {miner_evidence.url} | Is the same statement: {is_similar_excerpt} | Snippet Context: {statement_similarity_score}"
+        )
+
+        if is_similar_excerpt:
+            return StatementExcerptCheckResult(
+                early_exit_response=self._create_invalid_statement_response(
+                    miner_evidence, domain, EXCERPT_TOO_SIMILAR, "excerpt_too_similar",
+                    statement_similarity_score=statement_similarity_score,
+                ),
+                is_similar_excerpt=is_similar_excerpt,
+                statement_similarity_score=statement_similarity_score,
+            )
+
+        return StatementExcerptCheckResult(
+            early_exit_response=None,
+            is_similar_excerpt=is_similar_excerpt,
+            statement_similarity_score=statement_similarity_score,
+        )
+
+    async def _validate_desearch_snippet(
+        self,
+        request_id: str,
+        miner_uid: int,
+        original_statement: str,
+        miner_evidence: SourceEvidence,
+        bodies: typing.Sequence[bytes],
+    ) -> VericoreStatementResponse:
+        """Validate a snippet with source_type desearch: evidence-in-body only; no statement/excerpt or similarity validation (desearch assumed valid). NLI and assessment for signals. verify_miner_time_taken_secs set by caller on success."""
+        bodies = bodies or ()
+        if not bodies or not any(
+            self._evidence_in_desearch_response(miner_evidence.url, miner_evidence.excerpt, body)
+            for body in bodies
+        ):
+            return self._create_invalid_statement_response(
+                miner_evidence, "", DESEARCH_EVIDENCE_NOT_IN_RESPONSE, "desearch_evidence_not_in_response"
+            )
+
+        try:
+            domain = self._extract_domain(miner_evidence.url)
+        except InsecureProtocolError:
+            bt.logging.error(f"{request_id} | {miner_uid} | {miner_evidence.url} | Url provided isn't SSL")
+            return self._create_invalid_statement_response(
+                miner_evidence, "", SSL_DOMAIN_REQUIRED, "ssl_url_required"
+            )            
+        except Exception:
+            domain = ""
+
+        # Desearch evidence is assumed valid; skip statement/excerpt and similarity validation.
+
+        probs, local_score = await score_statement_distribution(
+            statement=original_statement.strip(),
+            snippet=miner_evidence.excerpt,
+        )
+
+        assessment_result, assess_statement_time_taken_secs = await self._run_assess_statement(
+            request_id=request_id,
+            miner_uid=miner_uid,
+            statement_url=miner_evidence.url,
+            statement=original_statement,
+            webpage=miner_evidence.excerpt,
+            miner_excerpt=miner_evidence.excerpt,
+        )
+        signals = self._extract_assessment_signals(assessment_result) if assessment_result else self._extract_assessment_signals({})
+
+        bt.logging.info(
+            f"{request_id} | {miner_uid} | {miner_evidence.url} | Desearch snippet validated | "
+            f"local_score: {local_score} | assess_secs: {assess_statement_time_taken_secs:.3f}s"
+        )
+        return VericoreStatementResponse(
+            url=miner_evidence.url,
+            excerpt=miner_evidence.excerpt,
+            domain=domain,
+            snippet_found=True,
+            domain_factor=0,
+            contradiction=probs["contradiction"],
+            neutral=probs["neutral"],
+            entailment=probs["entailment"],
+            local_score=local_score,
+            approved_url_multiplier=1,
+            snippet_score=0,
+            context_similarity_score=0.0,
+            statement_similarity_score=0.0,
+            is_similar_context=False,
+            assessment_result=assessment_result or {},
+            sentiment=signals["sentiment"],
+            conviction=signals["conviction"],
+            source_credibility=signals["source_credibility"],
+            narrative_momentum=signals["narrative_momentum"],
+            risk_reward_sentiment=signals["risk_reward_sentiment"],
+            catalyst_detection=signals["catalyst_detection"],
+            political_leaning=signals["political_leaning"],
+            verify_miner_time_taken_secs=0,
+            assess_statement_time_taken_secs=assess_statement_time_taken_secs,
+            timing=StatementResponseTiming(
+                verify_miner_time_taken_secs=0,
+                assess_statement_time_taken_secs=assess_statement_time_taken_secs,
+            ),
+        )
 
     async def validate_miner_snippet(
         self,
@@ -443,152 +608,173 @@ class SnippetValidator:
         miner_uid: int,
         original_statement: str,
         miner_evidence: SourceEvidence,
-        desearch_proof_valid: bool | None = None,
-        desearch_response_body: bytes | None = None,
+        desearch_response_bodies: typing.Sequence[bytes] | None = None,
     ) -> VericoreStatementResponse:
         start_time = time.perf_counter()
+        bodies = desearch_response_bodies or ()
 
         bt.logging.info(
             f"{request_id} | {miner_uid} | {miner_evidence.url} | Verifying miner snippet"
         )
         try:
-            # Desearch: require valid proof and evidence-from-body when source_type is desearch
-            source_type = getattr(miner_evidence, "source_type", "web")
-            if source_type == "desearch":
-                verify_secs = time.perf_counter() - start_time
-                if desearch_proof_valid is not True:
-                    return VericoreStatementResponse(
-                        url=miner_evidence.url,
-                        excerpt=miner_evidence.excerpt,
-                        domain="",
-                        snippet_found=False,
-                        local_score=0.0,
-                        snippet_score=0.0,
-                        snippet_score_reason="desearch_proof_invalid",
-                        verify_miner_time_taken_secs=verify_secs,
-                        timing=StatementResponseTiming(
-                            verify_miner_time_taken_secs=verify_secs,
-                        ),
-                    )
-                if not desearch_response_body:
-                    return VericoreStatementResponse(
-                        url=miner_evidence.url,
-                        excerpt=miner_evidence.excerpt,
-                        domain="",
-                        snippet_found=False,
-                        local_score=0.0,
-                        snippet_score=0.0,
-                        snippet_score_reason="desearch_proof_invalid",
-                        verify_miner_time_taken_secs=verify_secs,
-                        timing=StatementResponseTiming(
-                            verify_miner_time_taken_secs=verify_secs,
-                        ),
-                    )
-                if not self._evidence_in_desearch_response(
-                    miner_evidence.url, miner_evidence.excerpt, desearch_response_body
-                ):
-                    return VericoreStatementResponse(
-                        url=miner_evidence.url,
-                        excerpt=miner_evidence.excerpt,
-                        domain="",
-                        snippet_found=False,
-                        local_score=0.0,
-                        snippet_score=0.0,
-                        snippet_score_reason="desearch_evidence_not_in_response",
-                        verify_miner_time_taken_secs=verify_secs,
-                        timing=StatementResponseTiming(
-                            verify_miner_time_taken_secs=verify_secs,
-                        ),
-                    )
-                # Proof valid and evidence in body: continue to normal validation; we will add DESEARCH_SNIPPET_BONUS at the end
+            source_type_str = getattr(miner_evidence, "source_type", SourceType.WEB.value)
+            is_desearch = source_type_str == SourceType.DESEARCH.value
 
-            try:
-                domain = self._extract_domain(miner_evidence.url)
-            except InsecureProtocolError:
-                bt.logging.error(f"{request_id} | {miner_uid} | {miner_evidence.url} | Url provided isn't SSL")
-                snippet_score = SSL_DOMAIN_REQUIRED
-                verify_secs = time.perf_counter() - start_time
-                vericore_miner_response = VericoreStatementResponse(
-                    url=miner_evidence.url,
-                    excerpt=miner_evidence.excerpt,
-                    domain="",  # Not extracted; URL rejected for non-SSL
-                    snippet_found=False,
-                    local_score=0.0,
-                    snippet_score=snippet_score,
-                    snippet_score_reason="ssl_url_required",
-                    verify_miner_time_taken_secs=verify_secs,
-                    timing=StatementResponseTiming(
-                        verify_miner_time_taken_secs=verify_secs,
-                    ),
+            if is_desearch:
+                resp = await self._validate_desearch_snippet(
+                    request_id, miner_uid, original_statement, miner_evidence, bodies
                 )
-                return vericore_miner_response
+                return self._with_verify_time(resp, start_time)
 
-            bt.logging.info(
-                f"{request_id} | {miner_uid} | {miner_evidence.url} | Domain verified"
+            resp = await self._validate_web_snippet(
+                request_id, miner_uid, original_statement, miner_evidence
+            )
+            return self._with_verify_time(resp, start_time)
+        except Exception as e:
+            bt.logging.error(
+                f"{request_id} | {miner_uid} | Error fetching miner snippet {e}"
+            )
+            return self._create_invalid_statement_response(
+                miner_evidence, "", -1.0, "error_verifying_miner_snippet"
             )
 
-            vericore_miner_response = await self.validate_miner_url(
-                request_id=request_id,
-                miner_uid=miner_uid,
-                original_statement=original_statement,
+    async def _validate_web_snippet(
+        self,
+        request_id: str,
+        miner_uid: int,
+        original_statement: str,
+        miner_evidence: SourceEvidence,
+    ) -> VericoreStatementResponse:
+        """Validate a snippet with source_type web: domain/URL checks, page fetch, snippet-in-page verify, assessment, NLI. verify_miner_time_taken_secs set by caller on success."""
+        start_time = time.perf_counter()
+        try:
+            domain = self._extract_domain(miner_evidence.url)
+        except InsecureProtocolError:
+            bt.logging.error(f"{request_id} | {miner_uid} | {miner_evidence.url} | Url provided isn't SSL")
+            return self._create_invalid_statement_response(
+                miner_evidence, "", SSL_DOMAIN_REQUIRED, "ssl_url_required"
+            )
+
+        bt.logging.info(
+            f"{request_id} | {miner_uid} | {miner_evidence.url} | Domain verified"
+        )
+
+        vericore_miner_response = await self.validate_miner_url(
+            request_id=request_id,
+            miner_uid=miner_uid,
+            original_statement=original_statement,
+            domain=domain,
+            miner_evidence=miner_evidence
+        )
+        if vericore_miner_response is not None:
+            return vericore_miner_response
+
+        # check if snippet comes from verified domain
+        approved_url_multiplier = 1
+        if is_approved_site(request_id, miner_uid, domain):
+            approved_url_multiplier = APPROVED_URL_MULTIPLIER
+
+        bt.logging.info(
+            f"{request_id} | {miner_uid} | {miner_evidence.url} | Validating snippet"
+        )
+
+        excerpt_check = await self._check_statement_excerpt(
+            request_id, miner_uid, original_statement, miner_evidence, domain
+        )
+        if excerpt_check.early_exit_response is not None:
+            return excerpt_check.early_exit_response
+
+        snippet_str = miner_evidence.excerpt.strip()
+
+        bt.logging.info(
+            f"{request_id} | {miner_uid} | {miner_evidence.url} | Fetching page text"
+        )
+
+        # Fetch page text
+        fetch_page_start_time = time.perf_counter()
+        fetch_result = await self._fetch_page_text(request_id, miner_uid, miner_evidence.url)
+        fetch_page_time_taken_secs = time.perf_counter() - fetch_page_start_time
+        page_text = fetch_result.cleaned_html or ""
+        http_secs, selenium_secs, total_secs = self._snippet_fetcher_times(
+            fetch_result.fetch_by_http_time_secs, fetch_result.fetch_by_selenium_time_secs
+        )
+
+        # Could not extract page text from url
+        if not page_text:
+            snippet_score = COULD_NOT_GET_PAGE_TEXT_FROM_URL
+            vericore_miner_response = VericoreStatementResponse(
+                url=miner_evidence.url,
+                excerpt=miner_evidence.excerpt,
                 domain=domain,
-                miner_evidence=miner_evidence
+                snippet_found=False,
+                local_score=0.0,
+                snippet_score=snippet_score,
+                snippet_score_reason="could_not_extract_html_from_url",
+                verify_miner_time_taken_secs=0,
+                fetch_page_time_taken_secs=fetch_page_time_taken_secs,
+                snippet_fetcher_http_time_secs=http_secs,
+                snippet_fetcher_selenium_time_secs=selenium_secs,
+                snippet_fetcher_total_time_secs=total_secs,
+                cleaning_html_time_taken_secs=fetch_result.cleaning_html_time_secs,
+                fetch_by_http_status=fetch_result.fetch_by_http_status,
+                fetch_by_selenium_status=fetch_result.fetch_by_selenium_status,
+                timing=self._make_statement_timing(
+                    0, fetch_page_time_taken_secs, 0.0,
+                    http_secs, selenium_secs, total_secs,
+                    fetch_result.cleaning_html_time_secs,
+                    fetch_result.fetch_by_http_status, fetch_result.fetch_by_selenium_status,
+                ),
             )
-            if vericore_miner_response is not None:
-                return vericore_miner_response
+            return vericore_miner_response
 
-            # check if snippet comes from verified domain
-            approved_url_multiplier = 1
-            if is_approved_site(request_id, miner_uid, domain):
-                approved_url_multiplier = APPROVED_URL_MULTIPLIER
-
-            bt.logging.info(
-                f"{request_id} | {miner_uid} | {miner_evidence.url} | Validating snippet"
+        if is_search_web_page(page_text):
+            snippet_score = IS_SEARCH_WEB_PAGE
+            return VericoreStatementResponse(
+                url=miner_evidence.url,
+                excerpt=miner_evidence.excerpt,
+                domain=domain,
+                snippet_found=False,
+                local_score=0.0,
+                snippet_score=snippet_score,
+                snippet_score_reason="is_search_web_page",
+                verify_miner_time_taken_secs=0,
+                fetch_page_time_taken_secs=fetch_page_time_taken_secs,
+                snippet_fetcher_http_time_secs=http_secs,
+                snippet_fetcher_selenium_time_secs=selenium_secs,
+                snippet_fetcher_total_time_secs=total_secs,
+                cleaning_html_time_taken_secs=fetch_result.cleaning_html_time_secs,
+                fetch_by_http_status=fetch_result.fetch_by_http_status,
+                fetch_by_selenium_status=fetch_result.fetch_by_selenium_status,
+                timing=self._make_statement_timing(
+                    0, fetch_page_time_taken_secs, 0.0,
+                    http_secs, selenium_secs, total_secs,
+                    fetch_result.cleaning_html_time_secs,
+                    fetch_result.fetch_by_http_status, fetch_result.fetch_by_selenium_status,
+                ),
             )
 
-            snippet_str = miner_evidence.excerpt.strip()
-            # snippet was not processed - Score: -1
-            if not snippet_str:
-                snippet_score = NO_SNIPPET_PROVIDED
-                verify_secs = time.perf_counter() - start_time
-                vericore_miner_response = VericoreStatementResponse(
-                    url=miner_evidence.url,
-                    excerpt=miner_evidence.excerpt,
-                    domain=domain,
-                    snippet_found=False,
-                    local_score=0.0,
-                    snippet_score=snippet_score,
-                    snippet_score_reason="no_snippet_provided",
-                    verify_miner_time_taken_secs=verify_secs,
-                    timing=StatementResponseTiming(
-                        verify_miner_time_taken_secs=verify_secs,
-                    ),
-                )
-                return vericore_miner_response
+        bt.logging.info(
+            f"{request_id} | {miner_uid} | {miner_evidence.url} | Verifying snippet in rendered page"
+        )
 
-            # if article is the same as the excerpt - Score: -5
-            if snippet_str == original_statement.strip():
-                snippet_score = SNIPPET_SAME_AS_STATEMENT
-                verify_secs = time.perf_counter() - start_time
-                vericore_miner_response = VericoreStatementResponse(
-                    url=miner_evidence.url,
-                    excerpt=miner_evidence.excerpt,
-                    domain=domain,
-                    snippet_found=False,
-                    local_score=0.0,
-                    snippet_score=snippet_score,
-                    snippet_score_reason="snippet_same_as_statement",
-                    verify_miner_time_taken_secs=verify_secs,
-                    timing=StatementResponseTiming(
-                        verify_miner_time_taken_secs=verify_secs,
-                    ),
-                )
-                return vericore_miner_response
+        assessment_result, assess_statement_time_taken_secs = await self._run_assess_statement(
+            request_id=request_id,
+            miner_uid=miner_uid,
+            statement_url=miner_evidence.url,
+            statement=original_statement,
+            webpage=page_text,
+            miner_excerpt=miner_evidence.excerpt,
+        )
 
-            # Invalid excerpt - Score: -5
-            if not self.is_valid_separator_sentence(snippet_str):
-                snippet_score = INVALID_SNIPPET_EXCERPT
-                verify_secs = time.perf_counter() - start_time
+        bt.logging.info(
+            f"{request_id} | {miner_uid} | {miner_evidence.url} | Assessment Result: {assessment_result}"
+        )
+        if assessment_result is not None:
+            snippet_result = assessment_result.get("snippet_status")
+            is_search_url = assessment_result.get("is_search_url")
+
+            if snippet_result == "UNRELATED":
+                snippet_score = UNRELATED_PAGE_SNIPPET
                 return VericoreStatementResponse(
                     url=miner_evidence.url,
                     excerpt=miner_evidence.excerpt,
@@ -596,278 +782,10 @@ class SnippetValidator:
                     snippet_found=False,
                     local_score=0.0,
                     snippet_score=snippet_score,
-                    snippet_score_reason="invalid_excerpt",
-                    verify_miner_time_taken_secs=verify_secs,
-                    timing=StatementResponseTiming(
-                        verify_miner_time_taken_secs=verify_secs,
-                    ),
-                )
-
-            bt.logging.info(f"{request_id} | {miner_uid} | {miner_evidence.url} | Is snippet in same context as statement")
-
-            is_similar_excerpt, statement_similarity_score,  = await self.is_snippet_similar_to_statement(
-                request_id, miner_uid, miner_evidence.url, original_statement, snippet_str
-            )
-
-            bt.logging.info(f"{request_id} | {miner_uid} | {miner_evidence.url} | Is the same statement: {is_similar_excerpt} | Snippet Context: {statement_similarity_score}")
-
-            if is_similar_excerpt:
-                snippet_score = EXCERPT_TOO_SIMILAR
-                verify_secs = time.perf_counter() - start_time
-                return VericoreStatementResponse(
-                    url=miner_evidence.url,
-                    excerpt=miner_evidence.excerpt,
-                    domain=domain,
-                    snippet_found=False,
-                    local_score=0.0,
-                    snippet_score=snippet_score,
-                    snippet_score_reason="excerpt_too_similar",
-                    statement_similarity_score=statement_similarity_score,
-                    verify_miner_time_taken_secs=verify_secs,
-                    timing=StatementResponseTiming(
-                        verify_miner_time_taken_secs=verify_secs,
-                    ),
-                )
-
-            bt.logging.info(
-                f"{request_id} | {miner_uid} | {miner_evidence.url} | Fetching page text"
-            )
-
-            # Fetch page text
-            fetch_page_start_time = time.perf_counter()
-            fetch_result = await self._fetch_page_text(request_id, miner_uid, miner_evidence.url)
-            fetch_page_time_taken_secs = time.perf_counter() - fetch_page_start_time
-            page_text = fetch_result.cleaned_html
-
-            def _snippet_fetcher_times(http_secs: float, selenium_secs: float):
-                """Compute total_secs from fetch_by_http_time_secs and fetch_by_selenium_time_secs (already float, -1 if NA)."""
-                total_secs = -1
-                if http_secs >= 0 and selenium_secs >= 0:
-                    total_secs = http_secs + selenium_secs
-                elif http_secs >= 0:
-                    total_secs = http_secs
-                elif selenium_secs >= 0:
-                    total_secs = selenium_secs
-                return http_secs, selenium_secs, total_secs
-
-            def _make_statement_timing(
-                verify_secs: float,
-                fetch_page_secs: float,
-                assess_secs: float,
-                http_secs: float,
-                selenium_secs: float,
-                total_secs: float,
-                cleaning_secs: float,
-                http_status: str,
-                selenium_status: str,
-            ) -> StatementResponseTiming:
-                return StatementResponseTiming(
-                    verify_miner_time_taken_secs=verify_secs,
-                    fetch_page_time_taken_secs=fetch_page_secs,
-                    assess_statement_time_taken_secs=assess_secs,
-                    fetch_by_http_time_secs=http_secs,
-                    fetch_by_selenium_time_secs=selenium_secs,
-                    snippet_fetcher_total_time_secs=total_secs,
-                    cleaning_html_time_taken_secs=cleaning_secs,
-                    fetch_by_http_status=http_status,
-                    fetch_by_selenium_status=selenium_status,
-                )
-
-            http_secs, selenium_secs, total_secs = _snippet_fetcher_times(
-                fetch_result.fetch_by_http_time_secs, fetch_result.fetch_by_selenium_time_secs
-            )
-
-            # Could not extract page text from url
-            if page_text == '':
-                snippet_score = COULD_NOT_GET_PAGE_TEXT_FROM_URL
-                verify_secs = time.perf_counter() - start_time
-                vericore_miner_response = VericoreStatementResponse(
-                    url=miner_evidence.url,
-                    excerpt=miner_evidence.excerpt,
-                    domain=domain,
-                    snippet_found=False,
-                    local_score=0.0,
-                    snippet_score=snippet_score,
-                    snippet_score_reason="could_not_extract_html_from_url",
-                    verify_miner_time_taken_secs=verify_secs,
-                    fetch_page_time_taken_secs=fetch_page_time_taken_secs,
-                    snippet_fetcher_http_time_secs=http_secs,
-                    snippet_fetcher_selenium_time_secs=selenium_secs,
-                    snippet_fetcher_total_time_secs=total_secs,
-                    cleaning_html_time_taken_secs=fetch_result.cleaning_html_time_secs,
-                    fetch_by_http_status=fetch_result.fetch_by_http_status,
-                    fetch_by_selenium_status=fetch_result.fetch_by_selenium_status,
-                    timing=_make_statement_timing(
-                        verify_secs, fetch_page_time_taken_secs, 0.0,
-                        http_secs, selenium_secs, total_secs,
-                        fetch_result.cleaning_html_time_secs,
-                        fetch_result.fetch_by_http_status, fetch_result.fetch_by_selenium_status,
-                    ),
-                )
-                return vericore_miner_response
-
-            if is_search_web_page(page_text):
-                snippet_score = IS_SEARCH_WEB_PAGE
-                verify_secs = time.perf_counter() - start_time
-                return VericoreStatementResponse(
-                    url=miner_evidence.url,
-                    excerpt=miner_evidence.excerpt,
-                    domain=domain,
-                    snippet_found=False,
-                    local_score=0.0,
-                    snippet_score=snippet_score,
-                    snippet_score_reason="is_search_web_page",
-                    verify_miner_time_taken_secs=verify_secs,
-                    fetch_page_time_taken_secs=fetch_page_time_taken_secs,
-                    snippet_fetcher_http_time_secs=http_secs,
-                    snippet_fetcher_selenium_time_secs=selenium_secs,
-                    snippet_fetcher_total_time_secs=total_secs,
-                    cleaning_html_time_taken_secs=fetch_result.cleaning_html_time_secs,
-                    fetch_by_http_status=fetch_result.fetch_by_http_status,
-                    fetch_by_selenium_status=fetch_result.fetch_by_selenium_status,
-                    timing=_make_statement_timing(
-                        verify_secs, fetch_page_time_taken_secs, 0.0,
-                        http_secs, selenium_secs, total_secs,
-                        fetch_result.cleaning_html_time_secs,
-                        fetch_result.fetch_by_http_status, fetch_result.fetch_by_selenium_status,
-                    ),
-                )
-
-            bt.logging.info(
-                f"{request_id} | {miner_uid} | {miner_evidence.url} | Verifying snippet in rendered page"
-            )
-
-            assess_statement_start_time = time.perf_counter()
-            assessment_result = await assess_statement_async(
-                request_id=request_id,
-                miner_uid=miner_uid,
-                statement_url=miner_evidence.url,
-                statement=original_statement,
-                webpage=page_text,
-                miner_excerpt=miner_evidence.excerpt,
-            )
-            assess_statement_time_taken_secs = time.perf_counter() - assess_statement_start_time
-
-            bt.logging.info(
-                f"{request_id} | {miner_uid} | {miner_evidence.url} | Assessment Result: {assessment_result}"
-            )
-            if assessment_result is not None:
-                snippet_result = assessment_result.get("snippet_status")
-                is_search_url = assessment_result.get("is_search_url")
-
-                if snippet_result == "UNRELATED":
-                    snippet_score = UNRELATED_PAGE_SNIPPET
-                    verify_secs = time.perf_counter() - start_time
-                    return VericoreStatementResponse(
-                        url=miner_evidence.url,
-                        excerpt=miner_evidence.excerpt,
-                        domain=domain,
-                        snippet_found=False,
-                        local_score=0.0,
-                        snippet_score=snippet_score,
-                        snippet_score_reason="unrelated_page_snippet",
-                        rejection_reason = assessment_result.get("reason"),
-                        assessment_result = assessment_result,
-                        verify_miner_time_taken_secs=verify_secs,
-                        fetch_page_time_taken_secs=fetch_page_time_taken_secs,
-                        assess_statement_time_taken_secs=assess_statement_time_taken_secs,
-                        snippet_fetcher_http_time_secs=http_secs,
-                        snippet_fetcher_selenium_time_secs=selenium_secs,
-                        snippet_fetcher_total_time_secs=total_secs,
-                        cleaning_html_time_taken_secs=fetch_result.cleaning_html_time_secs,
-                        fetch_by_http_status=fetch_result.fetch_by_http_status,
-                        fetch_by_selenium_status=fetch_result.fetch_by_selenium_status,
-                        timing=_make_statement_timing(
-                            verify_secs, fetch_page_time_taken_secs, assess_statement_time_taken_secs,
-                            http_secs, selenium_secs, total_secs,
-                            fetch_result.cleaning_html_time_secs,
-                            fetch_result.fetch_by_http_status, fetch_result.fetch_by_selenium_status,
-                        ),
-                    )
-                elif snippet_result == "FAKE":
-                    snippet_score = FAKE_SNIPPET
-                    verify_secs = time.perf_counter() - start_time
-                    return VericoreStatementResponse(
-                        url=miner_evidence.url,
-                        excerpt=miner_evidence.excerpt,
-                        domain=domain,
-                        snippet_found=False,
-                        local_score=0.0,
-                        snippet_score=snippet_score,
-                        snippet_score_reason="fake_page_snippet",
-                        assessment_result=assessment_result,
-                        rejection_reason = assessment_result.get("reason"),
-                        verify_miner_time_taken_secs=verify_secs,
-                        fetch_page_time_taken_secs=fetch_page_time_taken_secs,
-                        assess_statement_time_taken_secs=assess_statement_time_taken_secs,
-                        snippet_fetcher_http_time_secs=http_secs,
-                        snippet_fetcher_selenium_time_secs=selenium_secs,
-                        snippet_fetcher_total_time_secs=total_secs,
-                        cleaning_html_time_taken_secs=fetch_result.cleaning_html_time_secs,
-                        fetch_by_http_status=fetch_result.fetch_by_http_status,
-                        fetch_by_selenium_status=fetch_result.fetch_by_selenium_status,
-                        timing=_make_statement_timing(
-                            verify_secs, fetch_page_time_taken_secs, assess_statement_time_taken_secs,
-                            http_secs, selenium_secs, total_secs,
-                            fetch_result.cleaning_html_time_secs,
-                            fetch_result.fetch_by_http_status, fetch_result.fetch_by_selenium_status,
-                        ),
-                    )
-                elif is_search_url:
-                    snippet_score = IS_SEARCH_WEB_PAGE
-                    verify_secs = time.perf_counter() - start_time
-                    return VericoreStatementResponse(
-                        url=miner_evidence.url,
-                        excerpt=miner_evidence.excerpt,
-                        domain=domain,
-                        snippet_found=False,
-                        local_score=0.0,
-                        snippet_score=snippet_score,
-                        assessment_result=assessment_result,
-                        snippet_score_reason="is_search_web_page",
-                        rejection_reason = assessment_result.get("reason"),
-                        verify_miner_time_taken_secs=verify_secs,
-                        fetch_page_time_taken_secs=fetch_page_time_taken_secs,
-                        assess_statement_time_taken_secs=assess_statement_time_taken_secs,
-                        snippet_fetcher_http_time_secs=http_secs,
-                        snippet_fetcher_selenium_time_secs=selenium_secs,
-                        snippet_fetcher_total_time_secs=total_secs,
-                        cleaning_html_time_taken_secs=fetch_result.cleaning_html_time_secs,
-                        fetch_by_http_status=fetch_result.fetch_by_http_status,
-                        fetch_by_selenium_status=fetch_result.fetch_by_selenium_status,
-                        timing=_make_statement_timing(
-                            verify_secs, fetch_page_time_taken_secs, assess_statement_time_taken_secs,
-                            http_secs, selenium_secs, total_secs,
-                            fetch_result.cleaning_html_time_secs,
-                            fetch_result.fetch_by_http_status, fetch_result.fetch_by_selenium_status,
-                        ),
-                    )
-
-            # Verify that the snippet is actually within the provided url
-            # #todo - should we split score between url exists and whether the web-page does include the snippet
-            snippet_found = await self._verify_snippet_in_rendered_page(
-                request_id, miner_uid, page_text, snippet_str, miner_evidence.url
-            )
-
-            bt.logging.info(
-                f"{request_id} | {miner_uid} | {miner_evidence.url} | Snippet Verified: {snippet_found}"
-            )
-
-            # Snippet was not found from the provided url:
-            if not snippet_found:
-                snippet_score = SNIPPET_NOT_VERIFIED_IN_URL
-                verify_secs = time.perf_counter() - start_time
-                vericore_miner_response = VericoreStatementResponse(
-                    url=miner_evidence.url,
-                    excerpt=miner_evidence.excerpt,
-                    domain=domain,
-                    snippet_found=False,
-                    local_score=0.0,
-                    snippet_score=snippet_score,
-                    snippet_score_reason="snippet_not_verified_in_url",
-                    assessment_result=assessment_result,
-                    page_text=page_text if DEBUG_LOCAL else "",
-                    verify_miner_time_taken_secs=verify_secs,
+                    snippet_score_reason="unrelated_page_snippet",
+                    rejection_reason = assessment_result.get("reason"),
+                    assessment_result = assessment_result,
+                    verify_miner_time_taken_secs=0,
                     fetch_page_time_taken_secs=fetch_page_time_taken_secs,
                     assess_statement_time_taken_secs=assess_statement_time_taken_secs,
                     snippet_fetcher_http_time_secs=http_secs,
@@ -876,75 +794,94 @@ class SnippetValidator:
                     cleaning_html_time_taken_secs=fetch_result.cleaning_html_time_secs,
                     fetch_by_http_status=fetch_result.fetch_by_http_status,
                     fetch_by_selenium_status=fetch_result.fetch_by_selenium_status,
-                    timing=_make_statement_timing(
-                        verify_secs, fetch_page_time_taken_secs, assess_statement_time_taken_secs,
+                    timing=self._make_statement_timing(
+                        0, fetch_page_time_taken_secs, assess_statement_time_taken_secs,
                         http_secs, selenium_secs, total_secs,
                         fetch_result.cleaning_html_time_secs,
                         fetch_result.fetch_by_http_status, fetch_result.fetch_by_selenium_status,
                     ),
                 )
-                return vericore_miner_response
+            elif snippet_result == "FAKE":
+                snippet_score = FAKE_SNIPPET
+                return VericoreStatementResponse(
+                    url=miner_evidence.url,
+                    excerpt=miner_evidence.excerpt,
+                    domain=domain,
+                    snippet_found=False,
+                    local_score=0.0,
+                    snippet_score=snippet_score,
+                    snippet_score_reason="fake_page_snippet",
+                    assessment_result=assessment_result,
+                    rejection_reason = assessment_result.get("reason"),
+                    verify_miner_time_taken_secs=0,
+                    fetch_page_time_taken_secs=fetch_page_time_taken_secs,
+                    assess_statement_time_taken_secs=assess_statement_time_taken_secs,
+                    snippet_fetcher_http_time_secs=http_secs,
+                    snippet_fetcher_selenium_time_secs=selenium_secs,
+                    snippet_fetcher_total_time_secs=total_secs,
+                    cleaning_html_time_taken_secs=fetch_result.cleaning_html_time_secs,
+                    fetch_by_http_status=fetch_result.fetch_by_http_status,
+                    fetch_by_selenium_status=fetch_result.fetch_by_selenium_status,
+                    timing=self._make_statement_timing(
+                        0, fetch_page_time_taken_secs, assess_statement_time_taken_secs,
+                        http_secs, selenium_secs, total_secs,
+                        fetch_result.cleaning_html_time_secs,
+                        fetch_result.fetch_by_http_status, fetch_result.fetch_by_selenium_status,
+                    ),
+                )
+            elif is_search_url:
+                snippet_score = IS_SEARCH_WEB_PAGE
+                return VericoreStatementResponse(
+                    url=miner_evidence.url,
+                    excerpt=miner_evidence.excerpt,
+                    domain=domain,
+                    snippet_found=False,
+                    local_score=0.0,
+                    snippet_score=snippet_score,
+                    assessment_result=assessment_result,
+                    snippet_score_reason="is_search_web_page",
+                    rejection_reason = assessment_result.get("reason"),
+                    verify_miner_time_taken_secs=0,
+                    fetch_page_time_taken_secs=fetch_page_time_taken_secs,
+                    assess_statement_time_taken_secs=assess_statement_time_taken_secs,
+                    snippet_fetcher_http_time_secs=http_secs,
+                    snippet_fetcher_selenium_time_secs=selenium_secs,
+                    snippet_fetcher_total_time_secs=total_secs,
+                    cleaning_html_time_taken_secs=fetch_result.cleaning_html_time_secs,
+                    fetch_by_http_status=fetch_result.fetch_by_http_status,
+                    fetch_by_selenium_status=fetch_result.fetch_by_selenium_status,
+                    timing=self._make_statement_timing(
+                        0, fetch_page_time_taken_secs, assess_statement_time_taken_secs,
+                        http_secs, selenium_secs, total_secs,
+                        fetch_result.cleaning_html_time_secs,
+                        fetch_result.fetch_by_http_status, fetch_result.fetch_by_selenium_status,
+                    ),
+                )
 
-            context_similarity_score = calculate_similarity_score(
-                statement=original_statement.strip(),
-                excerpt=miner_evidence.excerpt
-            )
+        # Verify that the snippet is actually within the provided url
+        # #todo - should we split score between url exists and whether the web-page does include the snippet
+        snippet_found = await self._verify_snippet_in_rendered_page(
+            request_id, miner_uid, page_text, snippet_str, miner_evidence.url
+        )
 
-            bt.logging.info(
-                f"{request_id} | {miner_uid} | {miner_evidence.url} | Context similarity: {context_similarity_score} "
-            )
+        bt.logging.info(
+            f"{request_id} | {miner_uid} | {miner_evidence.url} | Snippet Verified: {snippet_found}"
+        )
 
-            # Taken out for now since AI is checking context similarity - which is a better option
-            # # Zero score if excerpt isn't context similar to statement
-            # if context_similarity_score < MIN_SNIPPET_CONTEXT_SIMILARITY_SCORE:
-            #     snippet_score = SNIPPET_NOT_CONTEXT_SIMILAR
-            #     return VericoreStatementResponse(
-            #         url=miner_evidence.url,
-            #         excerpt=miner_evidence.excerpt,
-            #         domain=domain,
-            #         snippet_found=False,
-            #         local_score=0.0,
-            #         snippet_score=snippet_score,
-            #         snippet_score_reason="snippet_not_context_similar",
-            #         context_similarity_score=context_similarity_score,
-            #         assessment_result=assessment_result,
-            #         page_text=""
-            #     )
-
-            # Determine whether statement is neutral/corroborated or refuted
-            probs, local_score = await score_statement_distribution(
-                statement=original_statement.strip(),
-                snippet=miner_evidence.excerpt
-            )
-
-            end_time = time.perf_counter()
-            signals = self._extract_assessment_signals(assessment_result) if assessment_result else self._extract_assessment_signals({})
-            verify_secs = end_time - start_time
-            desearch_bonus = DESEARCH_SNIPPET_BONUS if source_type == "desearch" else 0.0
+        # Snippet was not found from the provided url:
+        if not snippet_found:
+            snippet_score = SNIPPET_NOT_VERIFIED_IN_URL
             vericore_miner_response = VericoreStatementResponse(
                 url=miner_evidence.url,
                 excerpt=miner_evidence.excerpt,
                 domain=domain,
-                snippet_found=True,
-                domain_factor=0,
-                contradiction=probs["contradiction"],
-                neutral=probs["neutral"],
-                entailment=probs["entailment"],
-                local_score=local_score,
-                approved_url_multiplier=approved_url_multiplier,
-                snippet_score=0,
-                context_similarity_score=context_similarity_score,
-                statement_similarity_score=statement_similarity_score,
-                is_similar_context=is_similar_excerpt,
+                snippet_found=False,
+                local_score=0.0,
+                snippet_score=snippet_score,
+                snippet_score_reason="snippet_not_verified_in_url",
                 assessment_result=assessment_result,
-                sentiment=signals["sentiment"],
-                conviction=signals["conviction"],
-                source_credibility=signals["source_credibility"],
-                narrative_momentum=signals["narrative_momentum"],
-                risk_reward_sentiment=signals["risk_reward_sentiment"],
-                catalyst_detection=signals["catalyst_detection"],
-                political_leaning=signals["political_leaning"],
-                verify_miner_time_taken_secs=verify_secs,
+                page_text=page_text if DEBUG_LOCAL else "",
+                verify_miner_time_taken_secs=0,
                 fetch_page_time_taken_secs=fetch_page_time_taken_secs,
                 assess_statement_time_taken_secs=assess_statement_time_taken_secs,
                 snippet_fetcher_http_time_secs=http_secs,
@@ -953,44 +890,133 @@ class SnippetValidator:
                 cleaning_html_time_taken_secs=fetch_result.cleaning_html_time_secs,
                 fetch_by_http_status=fetch_result.fetch_by_http_status,
                 fetch_by_selenium_status=fetch_result.fetch_by_selenium_status,
-                timing=_make_statement_timing(
-                    verify_secs, fetch_page_time_taken_secs, assess_statement_time_taken_secs,
+                timing=self._make_statement_timing(
+                    0, fetch_page_time_taken_secs, assess_statement_time_taken_secs,
                     http_secs, selenium_secs, total_secs,
                     fetch_result.cleaning_html_time_secs,
                     fetch_result.fetch_by_http_status, fetch_result.fetch_by_selenium_status,
                 ),
-                desearch_bonus=desearch_bonus,
-            )
-            total_time = end_time - start_time
-            other_time = total_time - fetch_page_time_taken_secs - assess_statement_time_taken_secs
-            bt.logging.info(
-                f"{request_id} | {miner_uid} | {miner_evidence.url} | Finished verifying miner snippet | "
-                f"Total: {total_time:.3f}s | Fetch: {fetch_page_time_taken_secs:.3f}s | AI: {assess_statement_time_taken_secs:.3f}s | Other: {other_time:.3f}s"
-            )
-
-            return vericore_miner_response
-        except Exception as e:
-            end_time = time.perf_counter()
-            bt.logging.error(
-                f"{request_id} | {miner_uid} | Error fetching miner snippet {e}"
-            )
-            snippet_score = -1.0
-            verify_secs = end_time - start_time
-            vericore_miner_response = VericoreStatementResponse(
-                url=miner_evidence.url,
-                excerpt=miner_evidence.excerpt,
-                domain=domain,
-                snippet_found=False,
-                local_score=0.0,
-                snippet_score=snippet_score,
-                snippet_score_reason="error_verifying_miner_snippet",
-                verify_miner_time_taken_secs=verify_secs,
-                timing=StatementResponseTiming(
-                    verify_miner_time_taken_secs=verify_secs,
-                ),
             )
             return vericore_miner_response
 
+        context_similarity_score = calculate_similarity_score(
+            statement=original_statement.strip(),
+            excerpt=miner_evidence.excerpt
+        )
+
+        bt.logging.info(
+            f"{request_id} | {miner_uid} | {miner_evidence.url} | Context similarity: {context_similarity_score} "
+        )
+
+        # Taken out for now since AI is checking context similarity - which is a better option
+        # # Zero score if excerpt isn't context similar to statement
+        # if context_similarity_score < MIN_SNIPPET_CONTEXT_SIMILARITY_SCORE:
+        #     snippet_score = SNIPPET_NOT_CONTEXT_SIMILAR
+        #     return VericoreStatementResponse(
+        #         url=miner_evidence.url,
+        #         excerpt=miner_evidence.excerpt,
+        #         domain=domain,
+        #         snippet_found=False,
+        #         local_score=0.0,
+        #         snippet_score=snippet_score,
+        #         snippet_score_reason="snippet_not_context_similar",
+        #         context_similarity_score=context_similarity_score,
+        #         assessment_result=assessment_result,
+        #         page_text=""
+        #     )
+
+        # Determine whether statement is neutral/corroborated or refuted
+        probs, local_score = await score_statement_distribution(
+            statement=original_statement.strip(),
+            snippet=miner_evidence.excerpt
+        )
+
+        end_time = time.perf_counter()
+        signals = self._extract_assessment_signals(assessment_result) if assessment_result else self._extract_assessment_signals({})
+        total_time = end_time - start_time
+        vericore_miner_response = VericoreStatementResponse(
+            url=miner_evidence.url,
+            excerpt=miner_evidence.excerpt,
+            domain=domain,
+            snippet_found=True,
+            domain_factor=0,
+            contradiction=probs["contradiction"],
+            neutral=probs["neutral"],
+            entailment=probs["entailment"],
+            local_score=local_score,
+            approved_url_multiplier=approved_url_multiplier,
+            snippet_score=0,
+            context_similarity_score=context_similarity_score,
+            statement_similarity_score=excerpt_check.statement_similarity_score,
+            is_similar_context=excerpt_check.is_similar_excerpt,
+            assessment_result=assessment_result,
+            sentiment=signals["sentiment"],
+            conviction=signals["conviction"],
+            source_credibility=signals["source_credibility"],
+            narrative_momentum=signals["narrative_momentum"],
+            risk_reward_sentiment=signals["risk_reward_sentiment"],
+            catalyst_detection=signals["catalyst_detection"],
+            political_leaning=signals["political_leaning"],
+            verify_miner_time_taken_secs=0,
+            fetch_page_time_taken_secs=fetch_page_time_taken_secs,
+            assess_statement_time_taken_secs=assess_statement_time_taken_secs,
+            snippet_fetcher_http_time_secs=http_secs,
+            snippet_fetcher_selenium_time_secs=selenium_secs,
+            snippet_fetcher_total_time_secs=total_secs,
+            cleaning_html_time_taken_secs=fetch_result.cleaning_html_time_secs,
+            fetch_by_http_status=fetch_result.fetch_by_http_status,
+            fetch_by_selenium_status=fetch_result.fetch_by_selenium_status,
+            timing=self._make_statement_timing(
+                0, fetch_page_time_taken_secs, assess_statement_time_taken_secs,
+                http_secs, selenium_secs, total_secs,
+                fetch_result.cleaning_html_time_secs,
+                fetch_result.fetch_by_http_status, fetch_result.fetch_by_selenium_status,
+            ),
+        )
+        other_time = total_time - fetch_page_time_taken_secs - assess_statement_time_taken_secs
+        bt.logging.info(
+            f"{request_id} | {miner_uid} | {miner_evidence.url} | Finished verifying miner snippet | "
+            f"Total: {total_time:.3f}s | Fetch: {fetch_page_time_taken_secs:.3f}s | AI: {assess_statement_time_taken_secs:.3f}s | Other: {other_time:.3f}s"
+        )
+
+        return vericore_miner_response
+
+    @staticmethod
+    def _snippet_fetcher_times(http_secs: float, selenium_secs: float) -> tuple[float, float, float]:
+        """Compute total_secs from fetch_by_http_time_secs and fetch_by_selenium_time_secs (already float, -1 if NA). Returns (http_secs, selenium_secs, total_secs)."""
+        total_secs = -1.0
+        if http_secs >= 0 and selenium_secs >= 0:
+            total_secs = http_secs + selenium_secs
+        elif http_secs >= 0:
+            total_secs = http_secs
+        elif selenium_secs >= 0:
+            total_secs = selenium_secs
+        return http_secs, selenium_secs, total_secs
+
+    def _make_statement_timing(
+        self,
+        verify_secs: float,
+        fetch_page_secs: float,
+        assess_secs: float,
+        http_secs: float,
+        selenium_secs: float,
+        total_secs: float,
+        cleaning_secs: float,
+        http_status: str,
+        selenium_status: str,
+    ) -> StatementResponseTiming:
+        """Build StatementResponseTiming for web snippet responses. Reusable for consistent timing shape."""
+        return StatementResponseTiming(
+            verify_miner_time_taken_secs=verify_secs,
+            fetch_page_time_taken_secs=fetch_page_secs,
+            assess_statement_time_taken_secs=assess_secs,
+            fetch_by_http_time_secs=http_secs,
+            fetch_by_selenium_time_secs=selenium_secs,
+            snippet_fetcher_total_time_secs=total_secs,
+            cleaning_html_time_taken_secs=cleaning_secs,
+            fetch_by_http_status=http_status,
+            fetch_by_selenium_status=selenium_status,
+        )
 
 
 validator = SnippetValidator()
@@ -1000,14 +1026,12 @@ async def run_validate_miner_snippet(
     miner_uid: int,
     original_statement: str,
     miner_evidence: SourceEvidence,
-    desearch_proof_valid: bool | None = None,
-    desearch_response_body: bytes | None = None,
+    desearch_response_bodies: typing.Sequence[bytes] | None = None,
 ) -> VericoreStatementResponse:
     return await validator.validate_miner_snippet(
         request_id,
         miner_uid,
         original_statement,
         miner_evidence,
-        desearch_proof_valid=desearch_proof_valid,
-        desearch_response_body=desearch_response_body,
+        desearch_response_bodies=desearch_response_bodies,
     )

--- a/validator/snippet_validator.py
+++ b/validator/snippet_validator.py
@@ -48,6 +48,8 @@ from shared.scores import (
     IS_SEARCH_WEB_PAGE,
     FAKE_SNIPPET,
     DESEARCH_EVIDENCE_NOT_IN_RESPONSE,
+    SOCIAL_BONUS_DOMAINS_X,
+    SOCIAL_BONUS_DOMAIN_REDDIT_NAME,
 )
 from validator.statement_context_evaluator import assess_statement_async
 from validator.web_page_validator import is_search_web_page
@@ -566,6 +568,14 @@ class SnippetValidator:
         )
         signals = self._extract_assessment_signals(assessment_result) if assessment_result else self._extract_assessment_signals({})
 
+        # For desearch: approved (top) sites = x.com / twitter.com / reddit.com OR domain in top_site cache
+        domain_lower = (domain or "").lower()
+        is_social_top = domain_lower in SOCIAL_BONUS_DOMAINS_X or domain_lower == SOCIAL_BONUS_DOMAIN_REDDIT_NAME
+        approved_url_multiplier = (
+            APPROVED_URL_MULTIPLIER
+            if is_social_top or is_approved_site(request_id, miner_uid, domain or "")
+            else 1
+        )
         bt.logging.info(
             f"{request_id} | {miner_uid} | {miner_evidence.url} | Desearch snippet validated | "
             f"local_score: {local_score} | assess_secs: {assess_statement_time_taken_secs:.3f}s"
@@ -580,7 +590,7 @@ class SnippetValidator:
             neutral=probs["neutral"],
             entailment=probs["entailment"],
             local_score=local_score,
-            approved_url_multiplier=1,
+            approved_url_multiplier=approved_url_multiplier,
             snippet_score=0,
             context_similarity_score=0.0,
             statement_similarity_score=0.0,

--- a/validator/snippet_validator.py
+++ b/validator/snippet_validator.py
@@ -383,12 +383,14 @@ class SnippetValidator:
     def _evidence_in_desearch_response(
         self, url: str, excerpt: str, response_body: bytes
     ) -> bool:
-        """Check if url is present in the Desearch response body (text or JSON). Excerpt is not checked."""
+        """Check if url is present in the Desearch response body (text or JSON). Excerpt is not checked. Empty URL must not pass."""
         try:
             if response_body is None:
                 return False
+            if not (url and url.strip()):
+                return False  # empty URL bypass would otherwise skip the body check
             text = response_body.decode("utf-8", errors="replace") or ""
-            if url and url not in text:
+            if url.strip() not in text:
                 return False
             return True
         except Exception:


### PR DESCRIPTION
# PR Summary: Story/mitchell/desearch integration

**PR:** [#84](https://github.com/dfusionai/Vericore/pull/84)  
**Branch:** `story/mitchell/desearch-integration` → `release/v0.0.43.4`  
**Risk:** **Medium** — Touches validator scoring and protocol shapes (new source types, proof verification, bonus/penalty logic). Can materially change miner weights; requires compatibility/testing across miners and downstream consumers.

---

## Overview

Adds first-class **Desearch-backed evidence** to the miner/validator protocol and scoring. The validator verifies Desearch proof signatures (bound to miner coldkey), applies a **miner-level bonus/penalty** (+2 / -5) and **per-snippet social bonus** for desearch snippets from `x.com`/`twitter.com` (+1) and `reddit.com` (+0.5) when proofs are valid. Desearch snippets use a relaxed validation path (URL-in-response-body only; no page fetch, blacklist, domain-age, or similarity checks) and updated domain-duplication handling.

---

## Protocol & Data Model

- **`SourceType`** — `WEB` | `DESEARCH`; evidence carries `source_type: "web"` or `"desearch"`.
- **`VericoreSynapse.desearch`** — Optional list of `Desearch` items: `response_body` (base64) and `proof` (signature, timestamp, expiry).
- **`DesearchProof`** — Proof headers from Desearch API (`X-Proof-Signature`, `X-Proof-Timestamp`, `X-Proof-Expiry`); signed message `coldkey|data_hash|timestamp|expiry` verified with Desearch’s public key.
- **Response fields** — `desearch_bonus_score`, `social_bonus_score`, `social_bonus_contribution` on statement responses.

---

## Validator Behavior

- **Proof verification:** If any evidence is `source_type == "desearch"`, `synapse.desearch` must be present with one entry per Desearch response; each must have body + proof. Validator verifies signature (and expiry) via `shared.desearch_proof.verify_proof`.
- **Desearch snippet validation:** For `desearch` snippets only the **evidence-in-body** check runs (URL must appear in the Desearch response body). Empty/whitespace-only URLs are rejected. No page fetch, blacklist, domain-age, or similarity checks.
- **Scoring:** Miner-level: valid proof **+2**, invalid/missing **-5** (once per miner response). Per-snippet: desearch evidence not in response body **-1**. Social bonus (desearch only, when proofs valid): `x.com`/`twitter.com` **+1**, `reddit.com` **+0.5**. Final score: `(sum_of_snippets * speed_factor) + desearch_adjustment + social_bonus_total`.
- **Domain handling:** Desearch “approved” domains for multiplier: `x.com`, `twitter.com`, `reddit.com` or domain in top_site cache; domain-duplication logic updated for desearch flow.

---

## Miner & Utilities

- **Reference Desearch miner** (`miner/desearch/miner.py`) — Calls Desearch API (SERP, web, Twitter), attaches proof to the synapse; sends `Authorization: <API_KEY>` (no Bearer prefix per project convention). Requires `DESEARCH_API_KEY` and coldkey linked via `POST /bt/miner/link`.
- **CLI/utils:** `utils/validate_desearch_signature.py`, `utils/link_desearch_miner.py`; `utils/test_desearch_verify.py` for proof verification.

---

## Tests & Hardening

- **Unit tests:** Proof verification (`tests/unit_tests/test_desearch_proof.py`), snippet dispatch and desearch validation path (`tests/unit_tests/snippet_validator_validate_miner_snippet_test.py`).
- **Hardening:** Dashboard domain caches and subtensor endpoint sanitization (small fixes).

---

## Docs

- Miner README and desearch flow/scoring docs updated (X and Reddit as approved URLs, domain factor 1 for these in desearch flow, negative scoring, auth behavior).

---

## Fixes Applied During Review

- **Empty URL bypass:** Validator rejects empty or whitespace-only URLs before the evidence-in-body check (`_evidence_in_desearch_response`).
- **Authorization header:** Miner uses `Authorization: <DESEARCH_API_KEY>` (no Bearer), per project convention (follow-up commit).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes validator scoring and protocol response shapes (new Desearch proof verification and bonus/penalty fields), which can materially affect miner rankings and downstream consumers.
> 
> **Overview**
> Adds first-class `desearch` evidence support end-to-end: miners can attach Desearch response bodies + proof headers to the synapse, and the validator verifies signatures/expiry bound to the miner coldkey before scoring.
> 
> Updates scoring to apply a **miner-level** Desearch bonus/penalty (`+2`/`-5`) plus an additional **per-snippet social bonus** for Desearch snippets from `x.com`/`twitter.com` and `reddit.com`, and adjusts domain-duplication handling and approved-domain multipliers accordingly. `validator/snippet_validator.py` is refactored to dispatch `web` vs `desearch` validation paths (Desearch uses URL-in-response-body checks and skips page fetch/blacklist/domain-age/similarity checks).
> 
> Extends `shared/veridex_protocol.py` with `SourceType`, `VericoreSynapse.desearch`, and new per-miner/per-snippet fields (`desearch_bonus_score`, `social_bonus_score`, `social_bonus_contribution`), adds proof verification/utilities/tests, and updates docs and miner setup instructions; also hardens domain cache fetching and sanitizes subtensor endpoint strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fd5b414c13def59b440be0ff28ffbd99296d801. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->