### PR TITLE
Story/mitchell/blacklist subdomain support

### DIFF
--- a/shared/blacklisted_domain_cache.py
+++ b/shared/blacklisted_domain_cache.py
@@ -3,53 +3,80 @@ import requests
 import time
 from shared.environment_variables import DASHBOARD_API_URL
 
-REFRESH_BLACKLISTED_DOMAIN_TIMEOUT = 60 * 60 # one hour
+REFRESH_BLACKLISTED_DOMAIN_TIMEOUT = 60 * 60  # one hour
+
 
 class BlacklistedDomainCache:
     def __init__(self):
         dashboard_api_url = DASHBOARD_API_URL
         self.url = f"{dashboard_api_url}/blacklisted-domains"
-        self.cache = self.fetch_blacklisted_domains()
+        self.domain_set = set()
+        self.subdomain_set = set()
         self.time_refreshed = None
+        result = self.fetch_blacklisted_domains()
+        if result is not None:
+            self.domain_set, self.subdomain_set = result
 
-
-    def fetch_blacklisted_domains(self) :
+    def fetch_blacklisted_domains(self) -> tuple[set[str], set[str]] | None:
         try:
             bt.logging.info(f"VALIDATOR | Fetching blacklisted domains from {self.url}")
             response = requests.get(self.url, timeout=300)
             bt.logging.info(f"VALIDATOR | blacklisted_domains_cache fetched")
-            # set time refreshed
             self.time_refreshed = time.time()
-            return {record["domain"] for record in response.json()}
+            domain_set: set[str] = set()
+            subdomain_set: set[str] = set()
+            for record in response.json():
+                d = record.get("domain")
+                if not d:
+                    continue
+                if record.get("is_subdomain", False):
+                    subdomain_set.add(d)
+                else:
+                    domain_set.add(d)
+            return (domain_set, subdomain_set)
         except requests.exceptions.RequestException as e:
             bt.logging.error(f"VALIDATOR | Failed to fetch blacklisted domains: {e}")
+            return None
 
-    def get_cache(self):
-        return self.cache
+    def get_cache(self) -> dict:
+        return {"domain_set": self.domain_set, "subdomain_set": self.subdomain_set}
 
     def requires_refresh(self) -> bool:
-        if blacklisted_domain_cache.cache is None:
-            return True
-        # bt.logging.info(f"time_refreshed: {self.time_refreshed is None}: {self.time_refreshed + REFRESH_BLACKLISTED_DOMAIN_TIMEOUT} : {time.time()}")
-        return self.time_refreshed is None or time.time() > self.time_refreshed + REFRESH_BLACKLISTED_DOMAIN_TIMEOUT
+        return (
+            self.time_refreshed is None
+            or time.time() > self.time_refreshed + REFRESH_BLACKLISTED_DOMAIN_TIMEOUT
+        )
+
 
 blacklisted_domain_cache = BlacklistedDomainCache()
 
-def get_blacklisted_domain_cache_data():
+
+def get_blacklisted_domain_cache_data() -> dict:
     if blacklisted_domain_cache.requires_refresh():
         bt.logging.info("Refreshing blacklisted domains cache")
-        blacklisted_domain_cache.cache = blacklisted_domain_cache.fetch_blacklisted_domains()
+        result = blacklisted_domain_cache.fetch_blacklisted_domains()
+        if result is not None:
+            blacklisted_domain_cache.domain_set, blacklisted_domain_cache.subdomain_set = result
+
+    return blacklisted_domain_cache.get_cache()
 
 
-    return blacklisted_domain_cache.cache
-
-
-def is_blacklisted_domain(request_id: str, miner_uid: int, domain: str):
+def is_blacklisted_domain(
+    request_id: str,
+    miner_uid: int,
+    domain: str,
+    hostname: str | None = None,
+) -> bool:
     bt.logging.info(f"{request_id} | {miner_uid} | Validating domain {domain}")
     cache_data = get_blacklisted_domain_cache_data()
+    domain_set = cache_data["domain_set"]
+    subdomain_set = cache_data["subdomain_set"]
 
-    blacklisted_domain = domain in cache_data
+    if hostname is not None:
+        blacklisted = (hostname in subdomain_set) or (domain in domain_set)
+    else:
+        blacklisted = domain in domain_set
 
-    bt.logging.info(f"{request_id} | {miner_uid} | {domain} is blacklisted : {blacklisted_domain} ")
+    bt.logging.info(f"{request_id} | {miner_uid} | {domain} is blacklisted : {blacklisted} ")
 
-    return blacklisted_domain
+    return blacklisted

--- a/validator/README.md
+++ b/validator/README.md
@@ -141,7 +141,7 @@ python -m validator.validator_daemon --wallet.name bittensor --wallet.hotkey val
 
 - `--wallet.name`: The name of the wallet.
 - `--wallet.hotkey`: The hotkey name for the validator.
-- `--subtensor.network`: The Bittensor network to connect to.
+- `--subtensor.network`: The Bittensor network to connect to. The URL must not have trailing spaces; the validator normalizes it automatically if present.
 
 ---
 

--- a/validator/api_server.py
+++ b/validator/api_server.py
@@ -76,6 +76,13 @@ EXPLORATION_FACTOR = 0.1  # 10% exploration
 NEW_MINER_BONUS = 2.0
 
 
+def normalize_endpoint(s: str | None) -> str | None:
+    """Strip leading/trailing whitespace (including Unicode NBSP U+00A0) from endpoint/URL strings."""
+    if not s or not isinstance(s, str):
+        return s
+    return s.strip()
+
+
 def get_parser():
     """Build argument parser with Bittensor and axon args (shared by get_config and __main__)."""
     parser = argparse.ArgumentParser()
@@ -130,6 +137,12 @@ class APIQueryHandler:
     def get_config(self):
         parser = get_parser()
         config = bt.config(parser)
+
+        # Normalize endpoint URLs so trailing Unicode whitespace (e.g. NBSP) does not break port parsing
+        if getattr(config.subtensor, "network", None):
+            config.subtensor.network = normalize_endpoint(config.subtensor.network)
+        if getattr(config.subtensor, "chain_endpoint", None):
+            config.subtensor.chain_endpoint = normalize_endpoint(config.subtensor.chain_endpoint)
 
         bt.logging.info(f"get_config: {config}")
         config.full_path = os.path.expanduser(
@@ -903,7 +916,7 @@ class JWTAuthMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
-app.add_middleware(JWTAuthMiddleware)
+# app.add_middleware(JWTAuthMiddleware)
 
 
 # Create the APIQueryHandler during startup and store it in app.state.

--- a/validator/api_server.py
+++ b/validator/api_server.py
@@ -916,7 +916,7 @@ class JWTAuthMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
-# app.add_middleware(JWTAuthMiddleware)
+app.add_middleware(JWTAuthMiddleware)
 
 
 # Create the APIQueryHandler during startup and store it in app.state.

--- a/validator/snippet_validator.py
+++ b/validator/snippet_validator.py
@@ -338,11 +338,17 @@ class SnippetValidator:
         miner_uid: int,
         original_statement: str,
         domain: str,
-        miner_evidence: SourceEvidence
+        miner_evidence: SourceEvidence,
+        hostname: str | None = None,
     ) -> VericoreStatementResponse | None:
 
         # Check if domain is blacklisted
-        if is_blacklisted_domain(request_id=request_id, miner_uid=miner_uid, domain=domain):
+        if is_blacklisted_domain(
+            request_id=request_id,
+            miner_uid=miner_uid,
+            domain=domain,
+            hostname=hostname,
+        ):
             snippet_score = BLACKLISTED_URL_SCORE
             return VericoreStatementResponse(
                 url=miner_evidence.url,
@@ -459,12 +465,14 @@ class SnippetValidator:
                 f"{request_id} | {miner_uid} | {miner_evidence.url} | Domain verified"
             )
 
+            hostname = urlparse(miner_evidence.url).hostname
             vericore_miner_response = await self.validate_miner_url(
                 request_id=request_id,
                 miner_uid=miner_uid,
                 original_statement=original_statement,
                 domain=domain,
-                miner_evidence=miner_evidence
+                miner_evidence=miner_evidence,
+                hostname=hostname,
             )
             if vericore_miner_response is not None:
                 return vericore_miner_response


### PR DESCRIPTION
# PR Summary: Blacklist subdomain support

**Branch:** `story/mitchell/blacklist-subdomain-support` → `release/v0.0.43.4`

---

## Summary

Adds subdomain-aware URL blacklisting and normalizes validator config so endpoint/port parsing is reliable.

---

## Changes

### 1. Subdomain-aware blacklist (`shared/blacklisted_domain_cache.py`)

- **BlacklistedDomainCache** keeps two sets from the dashboard API:
  - **domain_set** — root domains (`is_subdomain` false)
  - **subdomain_set** — subdomains (`is_subdomain` true)
- **fetch_blacklisted_domains()** returns `(domain_set, subdomain_set)` and fills them from each record’s `domain` and `is_subdomain`.
- **get_blacklisted_domain_cache_data()** returns `{"domain_set", "subdomain_set"}` instead of a single set.
- **is_blacklisted_domain(request_id, miner_uid, domain, hostname=None)**:
  - If **hostname** is provided: blacklisted if `hostname` is in `subdomain_set` or `domain` is in `domain_set`.
  - If **hostname** is omitted: blacklisted only if `domain` is in `domain_set` (previous behavior).

### 2. Snippet validator (`validator/snippet_validator.py`)

- **validate_miner_url()** takes an optional **hostname** and passes it to **is_blacklisted_domain()**.
- Hostname is taken from `urlparse(miner_evidence.url).hostname` and passed through so subdomain entries from the dashboard are applied correctly.

### 3. Config normalization (`validator/api_server.py`)

- **normalize_endpoint(s)** strips leading/trailing whitespace (including Unicode NBSP U+00A0) from endpoint strings.
- **get_config()** normalizes **config.subtensor.network** and **config.subtensor.chain_endpoint** so trailing/leading spaces do not break port or URL parsing.

### 4. Documentation (`validator/README.md`)

- Documents that `--subtensor.network` (and related endpoint URLs) must not have trailing spaces and that the validator normalizes them when present.

---

## Notes

- **Dashboard contract:** The blacklist API is expected to return a list of objects with `domain` and optional **is_subdomain** (boolean). Missing or inconsistent `is_subdomain` can affect scoring/validation.
- **JWT:** In the current tree, **JWTAuthMiddleware** is still registered; if this PR or a follow-up disables it (e.g. for testing), that should be called out as a security-sensitive change.

---

## Files touched

| Area            | File                               |
|-----------------|------------------------------------|
| Blacklist cache | `shared/blacklisted_domain_cache.py` |
| Validation      | `validator/snippet_validator.py`   |
| Config + startup| `validator/api_server.py`          |
| Docs            | `validator/README.md`             |